### PR TITLE
Configurable Receiver Middleware

### DIFF
--- a/docs/advanced_usage_custom_receiver.md
+++ b/docs/advanced_usage_custom_receiver.md
@@ -136,8 +136,28 @@ This allows separating the behaviors in configuring and handling the webhooks, w
 
 ## Webhook Handling
 
-When a webhook is received and the handlers are resolved, their execution is performed in sequence, and the middleware will wait for the completion of all the handlers before returning a response to the sender.
+When a webhook is received and the handlers are resolved, their execution is performed in parallel by default, and the middleware will wait for the completion of all the handlers before returning a response to the sender.
 
 It is recommended that implementations of the handlers are designed to be executed in a non-blocking form, to avoid blocking the middleware and the sender of the webhook: currently no background process is executed to handle the webhooks, and the middleware will wait for the completion of all the handlers before returning a response to the sender.
 
-_**Note**: This design might change in the future, to allow the execution of the handlers in parallel, or in background in a non-blocking form._
+## Execution Modes
+
+By default, the middleware will execute all the registered the handlers (fo the type of webhook) in parallel.
+
+This behavior can be changed by specifying an execution mode when registering the webhook receiver, using the `ExecutionMode` configuration property of the `WebhookHandlingOptions` class, when calling the `UseWebhookReceiver` method.
+
+```csharp
+namespace Example {
+	public class Startup {
+		public void ConfigureServices(IServiceCollection services) {
+			services.AddWebhookReceiver<IdentityWebhook>()
+				.AddHandler<UserCreatedHandler>();
+		}
+	}
+	public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+		app.UseWebhookReceiver<IdentityWebhook>("/ids/webhooks/", new WebhookHandlingOptions {
+			ExecutionMode = WebhookExecutionMode.Sequential;
+		});
+	}
+}
+```

--- a/docs/basic_usage_receive.md
+++ b/docs/basic_usage_receive.md
@@ -81,11 +81,11 @@ To use the middleware, you must first register it in the `Startup` class of your
 ```csharp
 public class Startup {
   public void ConfigureServices(IServiceCollection services) {
-    services.AddWebhooks<MyWebhook>();
+    services.AddWebhookReceiver<MyWebhook>();
   }
 
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
-	app.UseWebhooks<MyWebhook>("/webhook");
+	app.UseWebhookReceiver<MyWebhook>("/webhook");
   }
 }
 ```
@@ -95,11 +95,11 @@ If you are using the minimal API pattern, you can use the following code:
 ```csharp
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddWebhooks<MyWebhook>();
+builder.Services.AddWebhookReceiver<MyWebhook>();
 
 var app = builder.Build();
 
-app.UseWebhooks<MyWebhook>("/webhook");
+app.UseWebhookReceiver<MyWebhook>("/webhook");
 
 app.Run();
 ```
@@ -113,7 +113,7 @@ The middleware design allows to handle the webhooks without any prior registered
 ```csharp
 [...]
 
-app.UseWebhooks<MyWebhook>("/webhook", (context, webhook, cancellationToken) => {
+app.UseWebhookReceiver<MyWebhook>("/webhook", (context, webhook, cancellationToken) => {
   // Handle the webhook here
 });
 ```
@@ -123,7 +123,7 @@ Or a alternatively a synchronous handling delegate:
 ```csharp
 [...]
 
-app.UseWebhooks<MyWebhook>("/webhook", (context, webhook) => {
+app.UseWebhookReceiver<MyWebhook>("/webhook", (context, webhook) => {
   // Handle the webhook here
 });
 ```

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Deveel.Webhooks.Receiver.AspNetCore.xml
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Deveel.Webhooks.Receiver.AspNetCore.xml
@@ -10,7 +10,7 @@
             a receiver of a specific type of webhooks.
             </summary>
         </member>
-        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhooks``1(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhookReceiver``1(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
             Adds a receiver of webhooks of a specific type to the service collection.
             </summary>
@@ -23,7 +23,7 @@
             be used to further configure the receiver.
             </returns>
         </member>
-        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhooks``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String)">
+        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhookReceiver``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.String)">
             <summary>
             Adds a receiver of webhooks of a specific type to the service collection.
             </summary>
@@ -41,7 +41,7 @@
             be used to further configure the receiver.
             </returns>
         </member>
-        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhooks``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Deveel.Webhooks.WebhookReceiverOptions})">
+        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhookReceiver``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Deveel.Webhooks.WebhookReceiverOptions})">
             <summary>
             Adds a receiver of webhooks of a specific type to the service collection.
             </summary>
@@ -59,7 +59,7 @@
             be used to further configure the receiver.
             </returns>
         </member>
-        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhooks``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Deveel.Webhooks.WebhookReceiverBuilder{``0}})">
+        <member name="M:Deveel.ServiceCollectionExtensions.AddWebhookReceiver``1(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Deveel.Webhooks.WebhookReceiverBuilder{``0}})">
             <summary>
             Adds a receiver of webhooks of a specific type to the service collection.
             </summary>
@@ -83,7 +83,7 @@
             for receiving webhooks within an ASP.NET Core application request pipeline.
             </summary>
         </member>
-        <member name="M:Deveel.Webhooks.ApplicationBuilderExtensions.UseWebhookReceiver``1(Microsoft.AspNetCore.Builder.IApplicationBuilder,System.String)">
+        <member name="M:Deveel.Webhooks.ApplicationBuilderExtensions.UseWebhookReceiver``1(Microsoft.AspNetCore.Builder.IApplicationBuilder,System.String,Deveel.Webhooks.WebhookHandlingOptions)">
             <summary>
             Adds a middleware to the application pipeline that receives webhooks
             of that are posted to the given path.
@@ -432,6 +432,38 @@
         <member name="M:Deveel.Webhooks.SystemTextWebhookJsonParser`1.ParseWebhookAsync(System.IO.Stream,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="P:Deveel.Webhooks.WebhookHandlingOptions.ResponseStatusCode">
+            <summary>
+            Gets or sets the HTTP status code to return when the webhook
+            processing is successful (<c>201</c> by default).
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookHandlingOptions.ErrorStatusCode">
+            <summary>
+            Gets or sets the HTTP status code to return when the webhook
+            processing failed for an internal error (<c>500</c> by default).
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookHandlingOptions.InvalidStatusCode">
+            <summary>
+            Gets or sets the HTTP status code to return when the webhook
+            from the sender is invalid (<c>400</c> by default).
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookHandlingOptions.ExecutionMode">
+            <summary>
+            Gets or sets the execution mode for the handlers
+            during the processing of a received webhook 
+            (default: <see cref="F:Deveel.Webhooks.HandlerExecutionMode.Parallel"/>).
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookHandlingOptions.MaxParallelThreads">
+            <summary>
+            Gets or sets the maximum number of threads to use when
+            executing the handlers in parallel. By default the number
+            of processors in the machine is used.
+            </summary>
+        </member>
         <member name="T:Deveel.Webhooks.WebhookJsonParserExtensions">
             <summary>
             Extends the <see cref="T:Deveel.Webhooks.IWebhookJsonParser`1"/> with
@@ -694,7 +726,7 @@
             Gets the service collection to which the receiver is added
             </summary>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookReceiverBuilder`1.UseReceiver``1">
+        <member name="M:Deveel.Webhooks.WebhookReceiverBuilder`1.UseReceiver``1(Microsoft.Extensions.DependencyInjection.ServiceLifetime)">
             <summary>
             Registers an implementation of the <see cref="T:Deveel.Webhooks.IWebhookReceiver`1"/>
             that is used to receive the webhooks
@@ -957,6 +989,82 @@
         <member name="M:Deveel.Webhooks.WebhookReceiverException.#ctor">
             <inheritdoc/>
         </member>
+        <member name="T:Deveel.Webhooks.WebhookReceiverMiddleware`1">
+            <summary>
+            A middleware that handles the incoming webhooks through
+            HTTP requests sent to a specific path in a web application.
+            </summary>
+            <typeparam name="TWebhook">
+            The type of webhooks that are handled by this middleware
+            </typeparam>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookReceiverMiddleware`1.#ctor(Microsoft.AspNetCore.Http.RequestDelegate,Deveel.Webhooks.WebhookHandlingOptions,Microsoft.Extensions.Logging.ILogger{Deveel.Webhooks.WebhookReceiverMiddleware{`0}})">
+            <summary>
+            Constructs a new instance of the middleware
+            </summary>
+            <param name="next">
+            The next middleware in the pipeline of the web application
+            </param>
+            <param name="options">
+            An optional set of options to configure the middleware behaviors
+            </param>
+            <param name="logger">
+            A logger to use for tracing the execution of the middleware
+            </param>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookReceiverMiddleware`1.ReceiveWebhookAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Receives the webhook from the HTTP request context given.
+            </summary>
+            <param name="context">
+            The HTTP context of the request that contains the webhook
+            to be received.
+            </param>
+            <returns>
+            Returns the result of the webhook reception operation.
+            </returns>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookReceiverMiddleware`1.ResolveHandlers(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            Resolves the handlers that are registered in the service container
+            of the application.
+            </summary>
+            <param name="context">
+            The HTTP context that is executed by the middleware.
+            </param>
+            <returns>
+            Returns a sequence of handlers that are registered in the service
+            container of the application.
+            </returns>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookReceiverMiddleware`1.HandleWebhookAsync(Deveel.Webhooks.IWebhookHandler{`0},`0,System.Threading.CancellationToken)">
+            <summary>
+            Executes the given handler for the given webhook.
+            </summary>
+            <param name="handler">
+            The instance of the handler to be executed.
+            </param>
+            <param name="webhook">
+            The instance of the webhook to be handled.
+            </param>
+            <param name="cancellationToken">
+            A cancellation token to cancel the execution of the handler.
+            </param>
+            <returns>
+            Returns a task that completes when the handler has been executed.
+            </returns>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookReceiverMiddleware`1.InvokeAsync(Microsoft.AspNetCore.Http.HttpContext)">
+            <summary>
+            The main entry point of the middleware.
+            </summary>
+            <param name="context">
+            The HTTP context of the request that is executed by the middleware.
+            </param>
+            <returns>
+            Returns a task that completes when the middleware has finished
+            </returns>
+        </member>
         <member name="T:Deveel.Webhooks.WebhookReceiverOptions">
             <summary>
             Provides the configuration options for a webhook receiver.
@@ -971,38 +1079,6 @@
         <member name="P:Deveel.Webhooks.WebhookReceiverOptions.Signature">
             <summary>
             Gets or sets the options for the signature verification.
-            </summary>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverOptions.ResponseStatusCode">
-            <summary>
-            Gets or sets the HTTP status code to return when the webhook
-            processing is successful (<c>201</c> by default).
-            </summary>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverOptions.ErrorStatusCode">
-            <summary>
-            Gets or sets the HTTP status code to return when the webhook
-            processing failed for an internal error (<c>500</c> by default).
-            </summary>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverOptions.InvalidStatusCode">
-            <summary>
-            Gets or sets the HTTP status code to return when the webhook
-            from the sender is invalid (<c>400</c> by default).
-            </summary>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverOptions.ExecutionMode">
-            <summary>
-            Gets or sets the execution mode for the handlers
-            during the processing of a received webhook 
-            (default: <see cref="F:Deveel.Webhooks.HandlerExecutionMode.Parallel"/>).
-            </summary>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverOptions.MaxParallelThreads">
-            <summary>
-            Gets or sets the maximum number of threads to use when
-            executing the handlers in parallel. By default the number
-            of processors in the machine is used.
             </summary>
         </member>
         <member name="T:Deveel.Webhooks.WebhookRequestVerifier`1">

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/ServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Deveel {
 		/// Returns an instance of <see cref="WebhookReceiverBuilder{TWebhook}"/> that can
 		/// be used to further configure the receiver.
 		/// </returns>
-		public static WebhookReceiverBuilder<TWebhook> AddWebhooks<TWebhook>(this IServiceCollection services)
+		public static WebhookReceiverBuilder<TWebhook> AddWebhookReceiver<TWebhook>(this IServiceCollection services)
 			where TWebhook : class {
 			var builder = new WebhookReceiverBuilder<TWebhook>(services);
 
@@ -61,49 +61,49 @@ namespace Deveel {
 		/// Returns an instance of <see cref="WebhookReceiverBuilder{TWebhook}"/> that can
 		/// be used to further configure the receiver.
 		/// </returns>
-		public static WebhookReceiverBuilder<TWebhook> AddWebhooks<TWebhook>(this IServiceCollection services, string sectionPath)
+		public static WebhookReceiverBuilder<TWebhook> AddWebhookReceiver<TWebhook>(this IServiceCollection services, string sectionPath)
 			where TWebhook : class
-			=> services.AddWebhooks<TWebhook>().Configure(sectionPath);
+			=> services.AddWebhookReceiver<TWebhook>().Configure(sectionPath);
 
-        /// <summary>
-        /// Adds a receiver of webhooks of a specific type to the service collection.
-        /// </summary>
-        /// <typeparam name="TWebhook">
-        /// The type of webhooks to receive
-        /// </typeparam>
-        /// <param name="services">
-        /// The service collection to which the receiver is added
-        /// </param>
-        /// <param name="configure">
-        /// A configuraton action that can be used to further configure the receiver
-        /// </param>
-        /// <returns>
-        /// Returns an instance of <see cref="WebhookReceiverBuilder{TWebhook}"/> that can
-        /// be used to further configure the receiver.
-        /// </returns>
-        public static WebhookReceiverBuilder<TWebhook> AddWebhooks<TWebhook>(this IServiceCollection services, Action<WebhookReceiverOptions> configure) 
-            where TWebhook : class
-			=> services.AddWebhooks<TWebhook>().Configure(configure);
+		/// <summary>
+		/// Adds a receiver of webhooks of a specific type to the service collection.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of webhooks to receive
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to which the receiver is added
+		/// </param>
+		/// <param name="configure">
+		/// A configuraton action that can be used to further configure the receiver
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <see cref="WebhookReceiverBuilder{TWebhook}"/> that can
+		/// be used to further configure the receiver.
+		/// </returns>
+		public static WebhookReceiverBuilder<TWebhook> AddWebhookReceiver<TWebhook>(this IServiceCollection services, Action<WebhookReceiverOptions> configure)
+			where TWebhook : class
+			=> services.AddWebhookReceiver<TWebhook>().Configure(configure);
 
-        /// <summary>
-        /// Adds a receiver of webhooks of a specific type to the service collection.
-        /// </summary>
-        /// <typeparam name="TWebhook">
-        /// The type of webhooks to receive
-        /// </typeparam>
-        /// <param name="services">
-        /// The service collection to which the receiver is added
-        /// </param>
-        /// <param name="configure">
-        /// A configuraton action that can be used to further configure the receiver
-        /// </param>
+		/// <summary>
+		/// Adds a receiver of webhooks of a specific type to the service collection.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of webhooks to receive
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to which the receiver is added
+		/// </param>
+		/// <param name="configure">
+		/// A configuraton action that can be used to further configure the receiver
+		/// </param>
 		/// <returns>
 		/// Returns an instance of <see cref="IServiceCollection"/> that can be used to register
 		/// other services and configurations.
 		/// </returns>
-        public static IServiceCollection AddWebhooks<TWebhook>(this IServiceCollection services, Action<WebhookReceiverBuilder<TWebhook>> configure) 
+		public static IServiceCollection AddWebhookReceiver<TWebhook>(this IServiceCollection services, Action<WebhookReceiverBuilder<TWebhook>> configure) 
 			where TWebhook : class {
-			var builder = services.AddWebhooks<TWebhook>();
+			var builder = services.AddWebhookReceiver<TWebhook>();
 			configure?.Invoke(builder);
 
 			return services;

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/ApplicationBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/ApplicationBuilderExtensions.cs
@@ -43,11 +43,11 @@ namespace Deveel.Webhooks {
 		/// Returns the instance of the <see cref="IApplicationBuilder"/> that handles
 		/// webhooks posted to the given path.
 		/// </returns>
-		public static IApplicationBuilder UseWebhookReceiver<TWebhook>(this IApplicationBuilder app, string path)
+		public static IApplicationBuilder UseWebhookReceiver<TWebhook>(this IApplicationBuilder app, string path, WebhookHandlingOptions? options = null)
 			where TWebhook : class {
 			return app.MapWhen(
 				context => context.Request.Method == "POST" && context.Request.Path.Equals(path),
-				builder => builder.UseMiddleware<WebhookReceiverMiddleware<TWebhook>>()
+				builder => builder.UseMiddleware<WebhookReceiverMiddleware<TWebhook>>(options ?? new WebhookHandlingOptions())
 			);
 		}
 
@@ -138,7 +138,7 @@ namespace Deveel.Webhooks {
 			where TWebhook : class {
 			return app.MapWhen(
 				context => context.Request.Method == "POST" && context.Request.Path.Equals(path),
-				builder => builder.UseMiddleware<WebhookDelegatedReceiverMiddleware<TWebhook>>(receiver)
+				builder => builder.UseMiddleware<WebhookDelegatedReceiverMiddleware<TWebhook>>(new WebhookHandlingOptions(), receiver)
 			);
 		}
 
@@ -170,7 +170,7 @@ namespace Deveel.Webhooks {
 			where TWebhook : class {
 			return app.MapWhen(
 				context => context.Request.Method == "POST" && context.Request.Path.Equals(path),
-				builder => builder.UseMiddleware<WebhookDelegatedReceiverMiddleware<TWebhook>>(receiver)
+				builder => builder.UseMiddleware<WebhookDelegatedReceiverMiddleware<TWebhook>>(new WebhookHandlingOptions(), receiver)
 			);
 		}
 

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookHandlingOptions.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookHandlingOptions.cs
@@ -1,0 +1,35 @@
+﻿namespace Deveel.Webhooks {
+    public class WebhookHandlingOptions {
+        /// <summary>
+        /// Gets or sets the HTTP status code to return when the webhook
+        /// processing is successful (<c>201</c> by default).
+        /// </summary>
+        public int? ResponseStatusCode { get; set; } = 204;
+
+        /// <summary>
+        /// Gets or sets the HTTP status code to return when the webhook
+        /// processing failed for an internal error (<c>500</c> by default).
+        /// </summary>
+        public int? ErrorStatusCode { get; set; } = 500;
+
+        /// <summary>
+        /// Gets or sets the HTTP status code to return when the webhook
+        /// from the sender is invalid (<c>400</c> by default).
+        /// </summary>
+        public int? InvalidStatusCode { get; set; } = 400;
+
+        /// <summary>
+        /// Gets or sets the execution mode for the handlers
+        /// during the processing of a received webhook 
+        /// (default: <see cref="HandlerExecutionMode.Parallel"/>).
+        /// </summary>
+        public HandlerExecutionMode? ExecutionMode { get; set; } = HandlerExecutionMode.Parallel;
+
+        /// <summary>
+        /// Gets or sets the maximum number of threads to use when
+        /// executing the handlers in parallel. By default the number
+        /// of processors in the machine is used.
+        /// </summary>
+        public int? MaxParallelThreads { get; set; }
+    }
+}

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookHandlingOptions.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookHandlingOptions.cs
@@ -1,4 +1,8 @@
 ﻿namespace Deveel.Webhooks {
+    /// <summary>
+    /// Defines the options for the handling of a received webhook
+    /// from a single instance of a middleware of an application.
+    /// </summary>
     public class WebhookHandlingOptions {
         /// <summary>
         /// Gets or sets the HTTP status code to return when the webhook

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookReceiverBuilder.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookReceiverBuilder.cs
@@ -49,7 +49,7 @@ namespace Deveel.Webhooks {
 
 			Services.TryAddSingleton(this);
 
-			RegisterReceiverMiddleware();
+			// RegisterReceiverMiddleware();
 			RegisterDefaultServices();
 		}
 
@@ -66,17 +66,17 @@ namespace Deveel.Webhooks {
 		/// </summary>
 		public IServiceCollection Services { get; }
 
-		private void RegisterReceiverMiddleware() {
-			Services.TryAddScoped<WebhookReceiverMiddleware<TWebhook>>();
-		}
+		//private void RegisterReceiverMiddleware() {
+		//	Services.TryAddScoped<WebhookReceiverMiddleware<TWebhook>>();
+		//}
 
-		private void RegisterVerifierMiddleware() {
-			Services.TryAddScoped<WebhookRequestVerfierMiddleware<TWebhook>>();
-		}
+		//private void RegisterVerifierMiddleware() {
+		//	Services.TryAddScoped<WebhookRequestVerfierMiddleware<TWebhook>>();
+		//}
 
 		private void RegisterDefaultServices() {
-			Services.TryAddScoped<IWebhookReceiver<TWebhook>, WebhookReceiver<TWebhook>>();
-			Services.TryAddScoped<WebhookReceiver<TWebhook>>();
+			Services.TryAddTransient<IWebhookReceiver<TWebhook>, WebhookReceiver<TWebhook>>();
+			Services.TryAddTransient<WebhookReceiver<TWebhook>>();
 
 			Services.TryAddSingleton<IWebhookJsonParser<TWebhook>, SystemTextWebhookJsonParser<TWebhook>>();
 		}
@@ -91,13 +91,13 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns the current builder instance with the receiver registered
 		/// </returns>
-		public WebhookReceiverBuilder<TWebhook> UseReceiver<TReceiver>()
+		public WebhookReceiverBuilder<TWebhook> UseReceiver<TReceiver>(ServiceLifetime lifetime = ServiceLifetime.Transient)
 			where TReceiver : class, IWebhookReceiver<TWebhook> {
 
-			Services.AddScoped<IWebhookReceiver<TWebhook>, TReceiver>();
+			Services.Add(new ServiceDescriptor(typeof(TReceiver), typeof(TReceiver), lifetime));
 
 			if (!typeof(TReceiver).IsAbstract)
-				Services.AddScoped(typeof(TReceiver), typeof(TReceiver));
+				Services.Add(new ServiceDescriptor(typeof(TReceiver), typeof(TReceiver), lifetime));
 
 			return this;
 		}
@@ -115,7 +115,7 @@ namespace Deveel.Webhooks {
 		/// </returns>
 		public WebhookReceiverBuilder<TWebhook> UseVerifier<TVerifier>()
 			where TVerifier : class, IWebhookRequestVerifier<TWebhook> {
-			RegisterVerifierMiddleware();
+			// RegisterVerifierMiddleware();
 
 			Services.AddScoped<IWebhookRequestVerifier<TWebhook>, TVerifier>();
 

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookReceiverOptions.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Webhooks/WebhookReceiverOptions.cs
@@ -29,37 +29,5 @@ namespace Deveel.Webhooks {
 		/// Gets or sets the options for the signature verification.
 		/// </summary>
 		public WebhookSignatureOptions? Signature { get; set; } = new WebhookSignatureOptions();
-
-		/// <summary>
-		/// Gets or sets the HTTP status code to return when the webhook
-		/// processing is successful (<c>201</c> by default).
-		/// </summary>
-		public int? ResponseStatusCode { get; set; } = 204;
-
-		/// <summary>
-		/// Gets or sets the HTTP status code to return when the webhook
-		/// processing failed for an internal error (<c>500</c> by default).
-		/// </summary>
-		public int? ErrorStatusCode { get; set; } = 500;
-
-		/// <summary>
-		/// Gets or sets the HTTP status code to return when the webhook
-		/// from the sender is invalid (<c>400</c> by default).
-		/// </summary>
-		public int? InvalidStatusCode { get; set; } = 400;
-
-		/// <summary>
-		/// Gets or sets the execution mode for the handlers
-		/// during the processing of a received webhook 
-		/// (default: <see cref="HandlerExecutionMode.Parallel"/>).
-		/// </summary>
-		public HandlerExecutionMode? ExecutionMode { get; set; } = HandlerExecutionMode.Parallel;
-
-		/// <summary>
-		/// Gets or sets the maximum number of threads to use when
-		/// executing the handlers in parallel. By default the number
-		/// of processors in the machine is used.
-		/// </summary>
-		public int? MaxParallelThreads { get; set; }
 	}
 }

--- a/test/Deveel.Webhooks.Receiver.TestApi/Program.cs
+++ b/test/Deveel.Webhooks.Receiver.TestApi/Program.cs
@@ -11,12 +11,12 @@ namespace Deveel.Webhooks.Receiver.TestApi {
 			// Add services to the container.
 			builder.Services.AddAuthorization();
 			builder.Services
-				.AddWebhooks<TestWebhook>()
+				.AddWebhookReceiver<TestWebhook>()
 				.AddHandler<TestWebhookHandler>();
 
 			var secret = builder.Configuration["Webhook:Receiver:Signature:Secret"];
 
-			builder.Services.AddWebhooks<TestSignedWebhook>()
+			builder.Services.AddWebhookReceiver<TestSignedWebhook>()
 				.Configure(options => {
 					options.VerifySignature = true;
 					options.Signature!.Secret = secret;
@@ -42,7 +42,11 @@ namespace Deveel.Webhooks.Receiver.TestApi {
 			app.UseAuthorization();
 
 			app.UseWebhookReceiver<TestWebhook>("/webhook");
-			app.UseWebhookReceiver<TestWebhook>("/webhook/handled", (context, webhook) => {
+            app.UseWebhookReceiver<TestWebhook>("/webhook/seq", new WebhookHandlingOptions {
+				ExecutionMode = HandlerExecutionMode.Sequential
+			});
+
+            app.UseWebhookReceiver<TestWebhook>("/webhook/handled", (context, webhook) => {
 				var callback = context.RequestServices.GetRequiredService<IWebhookCallback<TestWebhook>>();
 
 				callback.OnWebhookHandled(webhook);


### PR DESCRIPTION
The WebhookReceiverMiddleware design has been changed radically to support configurations and extensions

* The WebhookReceiverMiddleware is now public and extensible (eg. to implement service-specific middleware, if needed)
* The middleware is not anymore factory-based but rather convention-based: it allows specifying configuration options for the single instance, that can be extended by implementations of service-specific options
* The options to handle the webhooks through the receiver middleware have been exported to another class, specific for the receiving operations.