### PR TITLE
Tracing Delivery of Webhooks

### DIFF
--- a/src/Deveel.Webhooks.Model/Deveel.Webhooks.Model.xml
+++ b/src/Deveel.Webhooks.Model/Deveel.Webhooks.Model.xml
@@ -100,6 +100,18 @@
             Describes the result of a webhook delivery operation
             </summary>
         </member>
+        <member name="P:Deveel.Webhooks.IWebhookDeliveryResult.OperationId">
+            <summary>
+            Gets the identifier of the operation that
+            attempted to deliver the webhook
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.IWebhookDeliveryResult.EventInfo">
+            <summary>
+            Gets the information about the event that
+            triggered the notification
+            </summary>
+        </member>
         <member name="P:Deveel.Webhooks.IWebhookDeliveryResult.Webhook">
             <summary>
             Gets the webhook that was notified

--- a/src/Deveel.Webhooks.Model/Webhooks/IWebhookDeliveryResult.cs
+++ b/src/Deveel.Webhooks.Model/Webhooks/IWebhookDeliveryResult.cs
@@ -21,6 +21,18 @@ namespace Deveel.Webhooks {
 	/// </summary>
 	public interface IWebhookDeliveryResult {
 		/// <summary>
+		/// Gets the identifier of the operation that
+		/// attempted to deliver the webhook
+		/// </summary>
+		string OperationId { get; }
+
+		/// <summary>
+		/// Gets the information about the event that
+		/// triggered the notification
+		/// </summary>
+		IEventInfo EventInfo { get; }
+
+		/// <summary>
 		/// Gets the webhook that was notified
 		/// </summary>
 		IWebhook Webhook { get; }

--- a/src/Deveel.Webhooks.Sender/Deveel.Webhooks.Sender.xml
+++ b/src/Deveel.Webhooks.Sender/Deveel.Webhooks.Sender.xml
@@ -465,16 +465,24 @@
             </para>
             </remarks>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookDeliveryResult`1.#ctor(Deveel.Webhooks.WebhookDestination,`0)">
+        <member name="M:Deveel.Webhooks.WebhookDeliveryResult`1.#ctor(System.String,Deveel.Webhooks.WebhookDestination,`0)">
             <summary>
             Constructs a new delivery result for the given webhook to the given destination.
             </summary>
+            <param name="operationId">
+            The unique identifier of the operation that delivered the webhook.
+            </param>
             <param name="destination">
             The destination of the webhook.
             </param>
             <param name="webhook">
             The webhook that was delivered.
             </param>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookDeliveryResult`1.OperationId">
+            <summary>
+            Gets the unique identifier of the operation that delivered the webhook.
+            </summary>
         </member>
         <member name="P:Deveel.Webhooks.WebhookDeliveryResult`1.Attempts">
             <summary>
@@ -806,16 +814,6 @@
             Thrown when the <paramref name="options"/> is <c>null</c>.
             </exception>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookDestinationVerifier`1.#ctor(Deveel.Webhooks.WebhookReceiverVerificationOptions,System.Net.Http.IHttpClientFactory,Microsoft.Extensions.Logging.ILogger)">
-            <summary>
-            Creates a new instance of the <see cref="T:Deveel.Webhooks.WebhookDestinationVerifier`1"/> class
-            that is configured with the given options and an optional factory of HTTP clients.
-            </summary>
-            <param name="options"></param>
-            <param name="httpClientFactory"></param>
-            <param name="logger"></param>
-            <exception cref="T:System.ArgumentNullException"></exception>
-        </member>
         <member name="M:Deveel.Webhooks.WebhookDestinationVerifier`1.#ctor(Deveel.Webhooks.WebhookSenderOptions{`0},System.Net.Http.HttpClient,Microsoft.Extensions.Logging.ILogger)">
             <summary>
             Creates a new instance of the <see cref="T:Deveel.Webhooks.WebhookDestinationVerifier`1"/> class
@@ -834,17 +832,7 @@
             Thrown when the <paramref name="options"/> is <c>null</c>.
             </exception>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookDestinationVerifier`1.#ctor(Deveel.Webhooks.WebhookReceiverVerificationOptions,System.Net.Http.HttpClient,Microsoft.Extensions.Logging.ILogger)">
-            <summary>
-            Creates a new instance of the <see cref="T:Deveel.Webhooks.WebhookDestinationVerifier`1"/> class
-            that is configured with the given options and an optional HTTP client.
-            </summary>
-            <param name="options"></param>
-            <param name="httpClient"></param>
-            <param name="logger"></param>
-            <exception cref="T:System.ArgumentNullException"></exception>
-        </member>
-        <member name="P:Deveel.Webhooks.WebhookDestinationVerifier`1.VerifierOptions">
+        <member name="P:Deveel.Webhooks.WebhookDestinationVerifier`1.SenderOptions">
             <summary>
             Gets the options used to configure the verifier service.
             </summary>
@@ -1003,11 +991,6 @@
             Gets or sets the timeout for the verification request.
             </summary>
         </member>
-        <member name="P:Deveel.Webhooks.WebhookReceiverVerificationOptions.Retry">
-            <summary>
-            Gets or sets the retry options for the verification request.
-            </summary>
-        </member>
         <member name="P:Deveel.Webhooks.WebhookReceiverVerificationOptions.HttpMethod">
             <summary>
             Gets or sets the HTTP method to use for the verification request.
@@ -1028,7 +1011,7 @@
         <member name="P:Deveel.Webhooks.WebhookReceiverVerificationOptions.Challenge">
             <summary>
             Gets or sets a value indicating whether the verification request
-            should be sent with a challenge response.
+            should be sent with a challenge response (default: <c>true</c>).
             </summary>
         </member>
         <member name="P:Deveel.Webhooks.WebhookReceiverVerificationOptions.ChallengeQueryParameter">
@@ -1305,6 +1288,40 @@
             </param>
             <exception cref="T:Deveel.Webhooks.WebhookSenderException">
             Thrown when the header cannot be added to the request.
+            </exception>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookSender`1.AddTraceHeader(System.Net.Http.HttpRequestMessage,System.String)">
+            <summary>
+            Adds the trace header to the request, if enabled.
+            </summary>
+            <param name="request">
+            The HTTP request to add the trace header to.
+            </param>
+            <param name="traceId">
+            The unique identifier of the current operation.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+            Thrown when the <paramref name="request"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Deveel.Webhooks.WebhookSenderException">
+            Thrown when the trace header cannot be added to the request.
+            </exception>
+        </member>
+        <member name="M:Deveel.Webhooks.WebhookSender`1.AddAttemptHeader(System.Net.Http.HttpRequestMessage,System.Int32)">
+            <summary>
+            Adds the attempt header to the request, if enabled.
+            </summary>
+            <param name="request">
+            The HTTP request to add the attempt header to.
+            </param>
+            <param name="attempt">
+            The attempt number to add to the header.
+            </param>
+            <exception cref="T:System.ArgumentNullException">
+            Thrown when the <paramref name="request"/> is <c>null</c>.
+            </exception>
+            <exception cref="T:Deveel.Webhooks.WebhookSenderException">
+            Thrown when the attempt header cannot be added to the request.
             </exception>
         </member>
         <member name="M:Deveel.Webhooks.WebhookSender`1.CreateRequest(Deveel.Webhooks.WebhookDestination)">
@@ -1586,6 +1603,83 @@
         <member name="M:Deveel.Webhooks.WebhookSenderClient.Dispose">
             <inheritdoc/>
         </member>
+        <member name="T:Deveel.Webhooks.WebhookSenderDefaults">
+            <summary>
+            The default configuration values for the webhooks sender.
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.AddTraceHeaders">
+            <summary>
+            Whether the sender should add trace headers to the 
+            HTTP request (default: <c>true</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.TraceHeaderName">
+            <summary>
+            The name of the header that will be used to send the
+            trace ID (default: <c>X-Webhook-TraceId</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.AttemptTraceHeaderName">
+            <summary>
+            The name of the header that will be used to send the
+            attempt number of the webhook (default: <c>X-Webhook-Attempt</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.SignatureLocation">
+            <summary>
+            The default location of the signature in the HTTP request
+            (default: <see cref="F:Deveel.Webhooks.WebhookSignatureLocation.Header"/>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.SignWebhooks">
+            <summary>
+            Gets the default value for the flag indicating if the
+            webhook request should be signed or not (default: <c>true</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.SignatureHeaderName">
+            <summary>
+            The default name of the header that will be used to send
+            the signature of the webhook (default: <c>X-Webhook-Signature</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.SignatureQueryParameterName">
+            <summary>
+            The default name of the query parameter that will be used
+            to send the signature of the webhook (default: <c>signature</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.Format">
+            <summary>
+            The default format of the webhook payload (default: <see cref="F:Deveel.Webhooks.WebhookFormat.Json"/>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.JsonContentType">
+            <summary>
+            The default content type for the JSON payload (default: <c>application/json</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.XmlContentType">
+            <summary>
+            The default content type for the XML payload (default: <c>text/xml</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.VerifyTokenHeaderName">
+            <summary>
+            The default header name for the verification token (default: <c>X-Verify-Token</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.VerifyTokenQueryParameterName">
+            <summary>
+            The default query parameter name for the verification token (default: <c>token</c>).
+            </summary>
+        </member>
+        <member name="F:Deveel.Webhooks.WebhookSenderDefaults.VerifyHttpMethod">
+            <summary>
+            The default HTTP method to use for the verification request (default: <c>GET</c>).
+            </summary>
+        </member>
         <member name="T:Deveel.Webhooks.WebhookSenderException">
             <summary>
             An exception thrown when an error occurs while sending a webhook.
@@ -1646,6 +1740,27 @@
             Gets or sets the timeout for the HTTP request to be sent,
             across all retries. When this is not set, the sender has no
             timeout to wait for the response.
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookSenderOptions`1.AddTraceHeaders">
+            <summary>
+            Gets or sets a flag indicating if the sender should add
+            trace headers to the HTTP request. When this is not set,
+            the default value is <c>true</c>.
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookSenderOptions`1.TraceHeaderName">
+            <summary>
+            Gets or sets the name of the header that will be used
+            to send the session trace ID. When this is not set, the
+            default value is <c>X-Webhook-TraceId</c>.
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookSenderOptions`1.AttemptTraceHeaderName">
+            <summary>
+            Gets or sets the name of the header that will be used to
+            send the attempt number of the webhook. When this is not
+            set the default value is <c>X-Webhook-Attempt</c>.
             </summary>
         </member>
         <member name="P:Deveel.Webhooks.WebhookSenderOptions`1.Signature">

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookDeliveryResult.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookDeliveryResult.cs
@@ -40,16 +40,28 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Constructs a new delivery result for the given webhook to the given destination.
 		/// </summary>
+		/// <param name="operationId">
+		/// The unique identifier of the operation that delivered the webhook.
+		/// </param>
 		/// <param name="destination">
 		/// The destination of the webhook.
 		/// </param>
 		/// <param name="webhook">
 		/// The webhook that was delivered.
 		/// </param>
-		public WebhookDeliveryResult(WebhookDestination destination, TWebhook webhook) {
+		public WebhookDeliveryResult(string operationId, WebhookDestination destination, TWebhook webhook) {
+			if (string.IsNullOrWhiteSpace(operationId)) 
+				throw new ArgumentException($"'{nameof(operationId)}' cannot be null or whitespace.", nameof(operationId));
+
 			Destination = destination ?? throw new ArgumentNullException(nameof(destination));
 			Webhook = webhook ?? throw new ArgumentNullException(nameof(webhook));
+			OperationId = operationId;
 		}
+
+		/// <summary>
+		/// Gets the unique identifier of the operation that delivered the webhook.
+		/// </summary>
+		public string OperationId { get; }
 
 		/// <summary>
 		/// Gets a read-only list of the delivery attempts that were made

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookReceiverVerificationOptions.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookReceiverVerificationOptions.cs
@@ -25,38 +25,33 @@ namespace Deveel.Webhooks {
         public TimeSpan? Timeout { get; set; }
 
 		/// <summary>
-		/// Gets or sets the retry options for the verification request.
-		/// </summary>
-		public WebhookRetryOptions? Retry { get; set; } = new WebhookRetryOptions();
-
-		/// <summary>
 		/// Gets or sets the HTTP method to use for the verification request.
 		/// </summary>
-        public string HttpMethod { get; set; } = "GET";
+        public string HttpMethod { get; set; } = WebhookSenderDefaults.VerifyHttpMethod;
 
 		/// <summary>
 		/// Gets or sets the query parameter name to use for passing the
 		/// token specific for the receiver in a verification request.
 		/// </summary>
-        public string TokenQueryParameter { get; set; } = "token";
+        public string TokenQueryParameter { get; set; } = WebhookSenderDefaults.VerifyTokenQueryParameterName;
 
 		/// <summary>
 		/// Gets or sets the header name to use for passing the
 		/// token specific for the receiver in a verification request.
 		/// </summary>
-        public string TokenHeaderName { get; set; } = "X-Verify-Token";
+        public string TokenHeaderName { get; set; } = WebhookSenderDefaults.VerifyTokenHeaderName;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether the verification request
-		/// should be sent with a challenge response.
+		/// should be sent with a challenge response (default: <c>true</c>).
 		/// </summary>
-		public bool? Challenge { get; set; }
+		public bool? Challenge { get; set; } = WebhookSenderDefaults.VerificationChallenge;
 
 		/// <summary>
 		/// Gets or sets the query parameter name to use for passing the
 		/// challenge to the receiver in a verification request.
 		/// </summary>
-		public string? ChallengeQueryParameter { get; set; } = "challenge";
+		public string? ChallengeQueryParameter { get; set; } = WebhookSenderDefaults.ChallengeQueryParameterName;
 
 		/// <summary>
 		/// Gets or sets the size of the challenge to be sent 
@@ -67,6 +62,6 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Gets or sets the location of the token in the verification request.
 		/// </summary>
-        public VerificationTokenLocation TokenLocation { get; set; }
+		public VerificationTokenLocation TokenLocation { get; set; } = WebhookSenderDefaults.DefaultVerificationTokenLocation;
 	}
 }

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderClient.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderClient.cs
@@ -63,6 +63,7 @@ namespace Deveel.Webhooks {
 			Logger = logger ?? NullLogger.Instance;
 		}
 
+		
 		/// <summary>
 		/// Gets the timeout for each request sent.
 		/// </summary>

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderDefaults.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderDefaults.cs
@@ -1,0 +1,84 @@
+﻿namespace Deveel.Webhooks {
+	/// <summary>
+	/// The default configuration values for the webhooks sender.
+	/// </summary>
+	public static class WebhookSenderDefaults {
+		/// <summary>
+		/// Whether the sender should add trace headers to the 
+		/// HTTP request (default: <c>true</c>).
+		/// </summary>
+		public const bool AddTraceHeaders = true;
+
+		/// <summary>
+		/// The name of the header that will be used to send the
+		/// trace ID (default: <c>X-Webhook-TraceId</c>).
+		/// </summary>
+		public const string TraceHeaderName = "X-Webhook-TraceId";
+
+		/// <summary>
+		/// The name of the header that will be used to send the
+		/// attempt number of the webhook (default: <c>X-Webhook-Attempt</c>).
+		/// </summary>
+		public const string AttemptTraceHeaderName = "X-Webhook-Attempt";
+
+		/// <summary>
+		/// The default location of the signature in the HTTP request
+		/// (default: <see cref="WebhookSignatureLocation.Header"/>).
+		/// </summary>
+		public const WebhookSignatureLocation SignatureLocation = WebhookSignatureLocation.Header;
+
+		/// <summary>
+		/// Gets the default value for the flag indicating if the
+		/// webhook request should be signed or not (default: <c>true</c>).
+		/// </summary>
+		public const bool SignWebhooks = true;
+
+		/// <summary>
+		/// The default name of the header that will be used to send
+		/// the signature of the webhook (default: <c>X-Webhook-Signature</c>).
+		/// </summary>
+		public const string SignatureHeaderName = "X-Webhook-Signature";
+
+		/// <summary>
+		/// The default name of the query parameter that will be used
+		/// to send the signature of the webhook (default: <c>signature</c>).
+		/// </summary>
+		public const string SignatureQueryParameterName = "signature";
+
+		/// <summary>
+		/// The default format of the webhook payload (default: <see cref="WebhookFormat.Json"/>).
+		/// </summary>
+		public const WebhookFormat Format = WebhookFormat.Json;
+
+		/// <summary>
+		/// The default content type for the JSON payload (default: <c>application/json</c>).
+		/// </summary>
+		public const string JsonContentType = "application/json";
+
+		/// <summary>
+		/// The default content type for the XML payload (default: <c>text/xml</c>).
+		/// </summary>
+		public const string XmlContentType = "text/xml";
+
+		/// <summary>
+		/// The default header name for the verification token (default: <c>X-Verify-Token</c>).
+		/// </summary>
+		public const string VerifyTokenHeaderName = "X-Verify-Token";
+
+		/// <summary>
+		/// The default query parameter name for the verification token (default: <c>token</c>).
+		/// </summary>
+		public const string VerifyTokenQueryParameterName = "token";
+
+		/// <summary>
+		/// The default HTTP method to use for the verification request (default: <c>GET</c>).
+		/// </summary>
+		public const string VerifyHttpMethod = "GET";
+
+		public const bool VerificationChallenge = false;
+
+		public const string ChallengeQueryParameterName = "challenge";
+
+		public const VerificationTokenLocation DefaultVerificationTokenLocation = VerificationTokenLocation.QueryString;
+	}
+}

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderOptions.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookSenderOptions.cs
@@ -38,7 +38,7 @@ namespace Deveel.Webhooks {
 		/// used when the destination does not specify a format to be used
 		/// (by default set to <see cref="WebhookFormat.Json"/>).
 		/// </summary>
-		public WebhookFormat DefaultFormat { get; set; } = WebhookFormat.Json;
+		public WebhookFormat DefaultFormat { get; set; } = WebhookSenderDefaults.Format;
 
 		/// <summary>
 		/// Gets or sets the options for the retry policy to be used
@@ -54,6 +54,27 @@ namespace Deveel.Webhooks {
 		/// timeout to wait for the response.
 		/// </summary>
 		public TimeSpan? Timeout { get; set; }
+
+		/// <summary>
+		/// Gets or sets a flag indicating if the sender should add
+		/// trace headers to the HTTP request. When this is not set,
+		/// the default value is <c>true</c>.
+		/// </summary>
+		public bool? AddTraceHeaders { get; set; } = WebhookSenderDefaults.AddTraceHeaders;
+
+		/// <summary>
+		/// Gets or sets the name of the header that will be used
+		/// to send the session trace ID. When this is not set, the
+		/// default value is <c>X-Webhook-TraceId</c>.
+		/// </summary>
+		public string? TraceHeaderName { get; set; } = WebhookSenderDefaults.TraceHeaderName;
+
+		/// <summary>
+		/// Gets or sets the name of the header that will be used to
+		/// send the attempt number of the webhook. When this is not
+		/// set the default value is <c>X-Webhook-Attempt</c>.
+		/// </summary>
+		public string? AttemptTraceHeaderName { get; set; } = WebhookSenderDefaults.AttemptTraceHeaderName;
 
 		/// <summary>
 		/// Gets or sets the options for the signature of the webhooks. Any
@@ -84,7 +105,7 @@ namespace Deveel.Webhooks {
 		/// is set and the <see cref="Signature"/> configurations are
 		/// provided.
 		/// </summary>
-		public bool? SignWebhooks { get; set; } = true;
+		public bool? SignWebhooks { get; set; } = WebhookSenderDefaults.SignWebhooks;
 
 		/// <summary>
 		/// An instance of a service that is used to sign the webhooks

--- a/src/Deveel.Webhooks.Service.MongoDb/Deveel.Webhooks.MongoDb.xml
+++ b/src/Deveel.Webhooks.Service.MongoDb/Deveel.Webhooks.MongoDb.xml
@@ -94,11 +94,14 @@
             Gets the logger used to log messages emitted by this service.
             </summary>
         </member>
-        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.ConvertResult(Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0})">
+        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.ConvertResult(Deveel.Webhooks.EventInfo,Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0})">
             <summary>
             Converts the given result to an object that can be stored in the
             MongoDB database collection.
             </summary>
+            <param name="eventInfo">
+            The information about the event that triggered the delivery of the webhook.
+            </param>
             <param name="subscription">
             The subscription for which the delivery result is logged.
             </param>
@@ -107,6 +110,18 @@
             </param>
             <returns>
             Returns an object that can be stored in the MongoDB database collection.
+            </returns>
+        </member>
+        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.CreateEvent(Deveel.Webhooks.EventInfo)">
+            <summary>
+            Converts the given webhook object to a MongoDB compatible object
+            </summary>
+            <param name="eventInfo">
+            The information about the event that triggered the delivery of the webhook.
+            </param>
+            <returns>
+            Returns an instance of <see cref="T:Deveel.Webhooks.MongoEventInfo"/> that can be stored
+            in a MongoDB database collection.
             </returns>
         </member>
         <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.CreateReceiver(Deveel.Webhooks.IWebhookSubscription)">
@@ -147,7 +162,7 @@
             no converter was provided.
             </exception>
         </member>
-        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.ConvertWebhookData(System.Object)">
+        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.ConvertData(System.Object)">
             <summary>
             Converts the webhook data to a <see cref="T:MongoDB.Bson.BsonDocument"/> that can
             be stored in the MongoDB database.
@@ -169,7 +184,7 @@
             </param>
             <returns></returns>
         </member>
-        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.LogResultAsync(Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
+        <member name="M:Deveel.Webhooks.MongoDbWebhookDeliveryResultLogger`2.LogResultAsync(Deveel.Webhooks.EventInfo,Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="T:Deveel.Webhooks.MongoDbWebhookDeliveryResultStore">
@@ -700,6 +715,30 @@
         <member name="M:Deveel.Webhooks.MongoDbWebhookTenantContext`1.OnConfigureMapping(MongoFramework.MappingBuilder)">
             <inheritdoc/>
         </member>
+        <member name="T:Deveel.Webhooks.MongoEventInfo">
+            <summary>
+            Provides an implementation of <see cref="T:Deveel.Webhooks.IEventInfo"/> that is
+            capable of being stored in a MongoDB database.
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.Subject">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.EventType">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.EventId">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.TimeStamp">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.DataVersion">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoEventInfo.EventData">
+            <inheritdoc/>
+        </member>
         <member name="T:Deveel.Webhooks.MongoWebhook">
             <summary>
             An implementation of the <see cref="T:Deveel.Webhooks.IWebhook"/> that is backed by a MongoDB database.
@@ -763,6 +802,15 @@
             <summary>
             Gets or sets the identifier of the delivery result entity.
             </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoWebhookDeliveryResult.EventInfo">
+            <summary>
+            Gets or sets the information on the event that
+            triggered the notification.
+            </summary>
+        </member>
+        <member name="P:Deveel.Webhooks.MongoWebhookDeliveryResult.OperationId">
+            <inheritdoc/>
         </member>
         <member name="P:Deveel.Webhooks.MongoWebhookDeliveryResult.Receiver">
             <inheritdoc/>

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoEventInfo.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoEventInfo.cs
@@ -1,0 +1,31 @@
+﻿using MongoDB.Bson;
+
+namespace Deveel.Webhooks {
+	/// <summary>
+	/// Provides an implementation of <see cref="IEventInfo"/> that is
+	/// capable of being stored in a MongoDB database.
+	/// </summary>
+	public class MongoEventInfo : IEventInfo {
+		/// <inheritdoc/>
+		public string Subject { get; set; }
+
+		/// <inheritdoc/>
+		public string EventType { get; set; }
+
+		/// <inheritdoc/>
+		public string EventId { get; set; }
+
+		string IEventInfo.Id => EventId;
+
+		/// <inheritdoc/>
+		public DateTimeOffset TimeStamp { get; set; }
+
+		/// <inheritdoc/>
+		public string? DataVersion { get; set; }
+
+		object? IEventInfo.Data => EventData;
+
+		/// <inheritdoc/>
+		public virtual BsonDocument EventData { get; set; }
+	}
+}

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoWebhookDeliveryResult.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoWebhookDeliveryResult.cs
@@ -36,6 +36,16 @@ namespace Deveel.Webhooks {
 
 		IWebhook IWebhookDeliveryResult.Webhook => Webhook;
 
+		/// <summary>
+		/// Gets or sets the information on the event that
+		/// triggered the notification.
+		/// </summary>
+		public MongoEventInfo EventInfo { get; set; }
+
+		IEventInfo IWebhookDeliveryResult.EventInfo => EventInfo;
+
+		/// <inheritdoc/>
+		public virtual string OperationId { get; set; }
 
         /// <inheritdoc/>
         public virtual MongoWebhookReceiver Receiver { get; set; }

--- a/src/Deveel.Webhooks/Deveel.Webhooks.xml
+++ b/src/Deveel.Webhooks/Deveel.Webhooks.xml
@@ -295,10 +295,13 @@
             The type of the webhook that is delivered
             </typeparam>
         </member>
-        <member name="M:Deveel.Webhooks.IWebhookDeliveryResultLogger`1.LogResultAsync(Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
+        <member name="M:Deveel.Webhooks.IWebhookDeliveryResultLogger`1.LogResultAsync(Deveel.Webhooks.EventInfo,Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
             <summary>
             Logs the result of a delivery of a webhook
             </summary>
+            <param name="eventInfo">
+            The information about the event that triggered the notification.
+            </param>
             <param name="subscription">
             The subscription that was used to deliver the webhook
             </param>
@@ -447,7 +450,7 @@
             Gets the singleton instance of the logger.
             </summary>
         </member>
-        <member name="M:Deveel.Webhooks.NullWebhookDeliveryResultLogger`1.LogResultAsync(Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
+        <member name="M:Deveel.Webhooks.NullWebhookDeliveryResultLogger`1.LogResultAsync(Deveel.Webhooks.EventInfo,Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="T:Deveel.Webhooks.ServiceCollectionExtensions">
@@ -493,10 +496,13 @@
             that addresses specific tenants
             </summary>
         </member>
-        <member name="M:Deveel.Webhooks.TenantWebhookNotifier`1.#ctor(Deveel.Webhooks.IWebhookSender{`0},Deveel.Webhooks.IWebhookFactory{`0},Deveel.Webhooks.ITenantWebhookSubscriptionResolver{`0},System.Collections.Generic.IEnumerable{Deveel.Webhooks.IWebhookFilterEvaluator{`0}},Deveel.Webhooks.IWebhookDeliveryResultLogger{`0},Microsoft.Extensions.Logging.ILogger{Deveel.Webhooks.TenantWebhookNotifier{`0}})">
+        <member name="M:Deveel.Webhooks.TenantWebhookNotifier`1.#ctor(Microsoft.Extensions.Options.IOptions{Deveel.Webhooks.WebhookNotificationOptions{`0}},Deveel.Webhooks.IWebhookSender{`0},Deveel.Webhooks.IWebhookFactory{`0},Deveel.Webhooks.ITenantWebhookSubscriptionResolver{`0},System.Collections.Generic.IEnumerable{Deveel.Webhooks.IWebhookFilterEvaluator{`0}},Deveel.Webhooks.IWebhookDeliveryResultLogger{`0},Microsoft.Extensions.Logging.ILogger{Deveel.Webhooks.TenantWebhookNotifier{`0}})">
             <summary>
             Constructs the notifier with the given services.
             </summary>
+            <param name="options">
+            The configuration options of the notifier.
+            </param>
             <param name="sender">
             The service used to send the webhook.
             </param>
@@ -675,6 +681,18 @@
             Returns <c>true</c> if the given <paramref name="filter"/> is a wildcard filter.
             </returns>
         </member>
+        <member name="T:Deveel.Webhooks.WebhookNotificationOptions`1">
+            <summary>
+            Provides configuration options for the notification of webhooks.
+            </summary>
+            <typeparam name="TWebhook"></typeparam>
+        </member>
+        <member name="P:Deveel.Webhooks.WebhookNotificationOptions`1.ParallelThreadCount">
+            <summary>
+            Gets or sets the number of parallel threads that will be used
+            to send the notifications.
+            </summary>
+        </member>
         <member name="T:Deveel.Webhooks.WebhookNotificationResult`1">
             <summary>
             Repsents an aggregated result of the notification of an event.
@@ -761,10 +779,13 @@
             The type of the webhook that is scoped for the notifier.
             </typeparam>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookNotifier`1.#ctor(Deveel.Webhooks.IWebhookSender{`0},Deveel.Webhooks.IWebhookFactory{`0},Deveel.Webhooks.IWebhookSubscriptionResolver{`0},System.Collections.Generic.IEnumerable{Deveel.Webhooks.IWebhookFilterEvaluator{`0}},Deveel.Webhooks.IWebhookDeliveryResultLogger{`0},Microsoft.Extensions.Logging.ILogger{Deveel.Webhooks.TenantWebhookNotifier{`0}})">
+        <member name="M:Deveel.Webhooks.WebhookNotifier`1.#ctor(Microsoft.Extensions.Options.IOptions{Deveel.Webhooks.WebhookNotificationOptions{`0}},Deveel.Webhooks.IWebhookSender{`0},Deveel.Webhooks.IWebhookFactory{`0},Deveel.Webhooks.IWebhookSubscriptionResolver{`0},System.Collections.Generic.IEnumerable{Deveel.Webhooks.IWebhookFilterEvaluator{`0}},Deveel.Webhooks.IWebhookDeliveryResultLogger{`0},Microsoft.Extensions.Logging.ILogger{Deveel.Webhooks.TenantWebhookNotifier{`0}})">
             <summary>
             Constructs the notifier with the given sender and factory.
             </summary>
+            <param name="options">
+            The configuration options of the notifier.
+            </param>
             <param name="sender">
             The service instance that will be used to send the notifications.
             </param>
@@ -891,10 +912,13 @@
             The result of the delivery operation.
             </param>
         </member>
-        <member name="M:Deveel.Webhooks.WebhookNotifierBase`1.LogDeliveryResultAsync(Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
+        <member name="M:Deveel.Webhooks.WebhookNotifierBase`1.LogDeliveryResultAsync(Deveel.Webhooks.EventInfo,Deveel.Webhooks.IWebhookSubscription,Deveel.Webhooks.WebhookDeliveryResult{`0},System.Threading.CancellationToken)">
             <summary>
             Logs the given delivery result.
             </summary>
+            <param name="eventInfo">
+            The information about the event that triggered the notification.
+            </param>
             <param name="subscription">
             The subscription that was used to send the webhook.
             </param>

--- a/src/Deveel.Webhooks/Webhooks/IWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookDeliveryResultLogger.cs
@@ -28,6 +28,9 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Logs the result of a delivery of a webhook
 		/// </summary>
+		/// <param name="eventInfo">
+		/// The information about the event that triggered the notification.
+		/// </param>
 		/// <param name="subscription">
 		/// The subscription that was used to deliver the webhook
 		/// </param>
@@ -40,6 +43,6 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that when completed will log the result of the delivery
 		/// </returns>
-		Task LogResultAsync(IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken = default);
+		Task LogResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/LoggerExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/LoggerExtensions.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Deveel.Webhooks {
+	static partial class LoggerExtensions {
+		[LoggerMessage(EventId = -10002, Level = LogLevel.Error,
+				Message = "An error occurred while trying to deliver a webhook to the subscription {SubscriptionId} and event {EventType}")]
+		public static partial void LogUnknownEventDeliveryError(this ILogger logger, Exception ex, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = -10001, Level = LogLevel.Error,
+		Message = "An error occurred while trying to deliver a webhook to the subscription {SubscriptionId}")]
+		public static partial void LogUnknownDeliveryError(this ILogger logger, Exception ex, string subscriptionId);
+
+
+		[LoggerMessage(EventId = - 10003, Level = LogLevel.Error,
+			Message = "Error while creating the webhook for the subscription {SubscriptionId} and event {EventType}")]
+		public static partial void LogWebhookCreationError(this ILogger logger, Exception ex, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = 100001, Level = LogLevel.Trace, 
+			Message = "The filter is empty - matching all subscriptions")]
+		public static partial void TraceEmptyFilter(this ILogger logger);
+
+		[LoggerMessage(EventId = 100003, Level = LogLevel.Trace, 
+			Message = "The filter is a wildcard - matching all subscriptions")]
+		public static partial void TraceWildcardFilter(this ILogger logger);
+
+		[LoggerMessage(EventId = 100004, Level = LogLevel.Debug,
+			Message = "Selecting an evaluator for filter of format '{FilterFormat}'")]
+		public static partial void TraceSelectingEvaluator(this ILogger logger, string filterFormat);
+
+		[LoggerMessage(EventId = 100005, Level = LogLevel.Warning,
+						Message = "The evaluator for filter of format '{FilterFormat}' was not found")]
+		public static partial void WarnEvaluatorNotFound(this ILogger logger, string filterFormat);
+
+		[LoggerMessage(EventId = 100002, Level = LogLevel.Debug, 
+									Message = "Evaluating the subscription {SubscriptionId} for event {EventType}")]
+		public static partial void TraceEvaluatingSubscription(this ILogger logger, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = 100023, Level = LogLevel.Debug, 
+			Message = "Subscription {SubscriptionId} matched the event {EventType}")]
+		public static partial void TraceSubscriptionMatched(this ILogger logger, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = 100024, Level = LogLevel.Debug, 
+			Message = "Subscription {SubscriptionId} did not match the event {EventType}")]
+		public static partial void TraceSubscriptionNotMatched(this ILogger logger, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = -100200, Level = LogLevel.Warning,
+			Message = "The webhook was not created for the subscription {SubscriptionId} and event {EventType}")]
+		public static partial void WarnWebhookNotCreated(this ILogger logger, string subscriptionId, string eventType);
+
+		[LoggerMessage(EventId = 100200, Level = LogLevel.Warning,
+			Message = "No attempts to deliver the webhook for event {EventType} to {DestinationUrl} were done")]
+		public static partial void WarnDeliveryNotAttempted(this ILogger logger, string destinationUrl, string eventType);
+
+		[LoggerMessage(EventId = 100201, Level = LogLevel.Debug,
+			Message = "The webhook for event {EventType} was delivered to {DestinationUrl} after {AttemptCount} attempts")]
+		public static partial void TraceDeliveryDoneAfterAttempts(this ILogger logger, string destinationUrl, string eventType, int attemptCount);
+
+		[LoggerMessage(EventId = -100202, Level = LogLevel.Warning,
+			Message = "The webhook for event {EventType} failed to deliver to {DestinationUrl} after {AttemptCount} attempts")]
+		public static partial void WarnDeliveryFailed(this ILogger logger, string destinationUrl, string eventType, int attemptCount);
+
+		[LoggerMessage(EventId = 100202, Level = LogLevel.Trace,
+			Message = "Attempt {AttemptNumber} successfull - started at {StartedAt}, completed at {CompletedAt}, responseCode {ResponseCode}")]
+		public static partial void TraceDeliveryAttemptSuccess(this ILogger logger, int attemptNumber, DateTimeOffset startedAt, DateTimeOffset? completedAt, int? responseCode);
+
+		[LoggerMessage(EventId = 100203, Level = LogLevel.Trace,
+			Message = "Attempt {AttemptNumber} failed - started at {StartedAt}, completed at {CompletedAt}, responseCode {ResponseCode}")]
+		public static partial void TraceDeliveryAttemptFailed(this ILogger logger, int attemptNumber, DateTimeOffset startedAt, DateTimeOffset? completedAt, int? responseCode);
+
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/NullWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks/Webhooks/NullWebhookDeliveryResultLogger.cs
@@ -34,7 +34,7 @@ namespace Deveel.Webhooks {
 		public static readonly NullWebhookDeliveryResultLogger<TWebhook> Instance = new NullWebhookDeliveryResultLogger<TWebhook>();
 
 		/// <inheritdoc/>
-		public Task LogResultAsync(IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
+		public Task LogResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
 			return Task.CompletedTask;
 		}
 	}

--- a/src/Deveel.Webhooks/Webhooks/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/ServiceCollectionExtensions.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Deveel.Webhooks {
 	/// <summary>
@@ -46,6 +41,32 @@ namespace Deveel.Webhooks {
 			services.TryAddSingleton(builder);
 
 			return builder;
+		}
+
+		public static WebhookNotifierBuilder<TWebhook> AddWebhookNotifier<TWebhook>(this IServiceCollection services, WebhookNotificationOptions<TWebhook> options)
+			where TWebhook : class {
+
+			services.AddSingleton(Options.Create(options));
+
+			return services.AddWebhookNotifier<TWebhook>();
+		}
+
+		public static WebhookNotifierBuilder<TWebhook> AddWebhookNotifier<TWebhook>(this IServiceCollection services, Action<WebhookNotificationOptions<TWebhook>> configure)
+			where TWebhook : class {
+
+			services.AddOptions<WebhookNotificationOptions<TWebhook>>()
+				.Configure(configure);
+
+			return services.AddWebhookNotifier<TWebhook>();
+		}
+
+		public static WebhookNotifierBuilder<TWebhook> AddWebhookNotifier<TWebhook>(this IServiceCollection services, string sectionPath)
+			where TWebhook : class {
+
+			services.AddOptions<WebhookNotificationOptions<TWebhook>>()
+				.BindConfiguration(sectionPath);
+
+			return services.AddWebhookNotifier<TWebhook>();
 		}
 
 		/// <summary>

--- a/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifier.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Deveel.Webhooks {
 	/// <summary>
@@ -32,6 +33,9 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Constructs the notifier with the given services.
 		/// </summary>
+		/// <param name="options">
+		/// The configuration options of the notifier.
+		/// </param>
 		/// <param name="sender">
 		/// The service used to send the webhook.
 		/// </param>
@@ -53,12 +57,14 @@ namespace Deveel.Webhooks {
 		/// A logger used to log the activity of the notifier.
 		/// </param>
 		public TenantWebhookNotifier(
+			IOptions<WebhookNotificationOptions<TWebhook>> options,
 			IWebhookSender<TWebhook> sender,
 			IWebhookFactory<TWebhook> webhookFactory,
 			ITenantWebhookSubscriptionResolver<TWebhook>? subscriptionResolver = null,
 			IEnumerable<IWebhookFilterEvaluator<TWebhook>>? filterEvaluators = null,
 			IWebhookDeliveryResultLogger<TWebhook>? deliveryResultLogger = null,
-			ILogger<TenantWebhookNotifier<TWebhook>>? logger = null) : base(sender, webhookFactory, filterEvaluators, deliveryResultLogger, logger) {
+			ILogger<TenantWebhookNotifier<TWebhook>>? logger = null) 
+			: base(options.Value, sender, webhookFactory, filterEvaluators, deliveryResultLogger, logger) {
 			this.subscriptionResolver = subscriptionResolver;
 		}
 

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotificationOptions.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotificationOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Deveel.Webhooks {
+	/// <summary>
+	/// Provides configuration options for the notification of webhooks.
+	/// </summary>
+	/// <typeparam name="TWebhook"></typeparam>
+	public class WebhookNotificationOptions<TWebhook> {
+		/// <summary>
+		/// Gets or sets the number of parallel threads that will be used
+		/// to send the notifications.
+		/// </summary>
+		public int ParallelThreadCount { get; set; } = Environment.ProcessorCount - 1;
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifier.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Deveel.Webhooks {
 	/// <summary>
@@ -27,6 +28,9 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Constructs the notifier with the given sender and factory.
 		/// </summary>
+		/// <param name="options">
+		/// The configuration options of the notifier.
+		/// </param>
 		/// <param name="sender">
 		/// The service instance that will be used to send the notifications.
 		/// </param>
@@ -47,13 +51,14 @@ namespace Deveel.Webhooks {
 		/// A logger instance used to log the activity of the notifier.
 		/// </param>
 		public WebhookNotifier(
+			IOptions<WebhookNotificationOptions<TWebhook>> options,
 			IWebhookSender<TWebhook> sender, 
 			IWebhookFactory<TWebhook> webhookFactory,
 			IWebhookSubscriptionResolver<TWebhook>? subscriptionResolver = null,
 			IEnumerable<IWebhookFilterEvaluator<TWebhook>>? filterEvaluators = null, 
 			IWebhookDeliveryResultLogger<TWebhook>? deliveryResultLogger = null, 
 			ILogger<TenantWebhookNotifier<TWebhook>>? logger = null) 
-			: base(sender, webhookFactory, filterEvaluators, deliveryResultLogger, logger) {
+			: base(options.Value, sender, webhookFactory, filterEvaluators, deliveryResultLogger, logger) {
 			this.subscriptionResolver = subscriptionResolver;
 		}
 

--- a/test/Deveel.Events.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
+++ b/test/Deveel.Events.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
@@ -239,6 +239,25 @@ namespace Deveel.Webhooks {
 		}
 
 		[Fact]
+		public async Task DeliverWenhookWithFilterTypeNotRegistered() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created",
+						new WebhookFilter("hook.data.type == \"test\"", "query"),
+						new WebhookFilter("hook.data.creator.user_name == \"antonello\"", "query"));
+
+			var notification = new EventInfo("test", "data.created", data: new {
+				creator = new {
+					user_name = "antonello"
+				},
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+			Assert.NotNull(result);
+			Assert.Empty(result);
+		}
+
+		[Fact]
 		public async Task DeliverSignedWebhookFromEvent() {
 			var subscriptionId = CreateSubscription(new TestWebhookSubscription {
 				EventTypes = new[] { "data.created" },
@@ -336,7 +355,7 @@ namespace Deveel.Webhooks {
 
 		[Fact]
 		public async Task NoSubscriptionMatches() {
-			CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.data_type == \"test-data2\"", "linq"));
+			CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test-data2\"", "linq"));
 			var notification = new EventInfo("test", "data.created", data: new {
 				creationTime = DateTimeOffset.UtcNow,
 				type = "test"

--- a/test/Deveel.Events.Webhooks.XUnit/Webhooks/WebhookServiceTestBase.cs
+++ b/test/Deveel.Events.Webhooks.XUnit/Webhooks/WebhookServiceTestBase.cs
@@ -36,7 +36,7 @@ namespace Deveel.Webhooks {
 			return new ServiceCollection()
 				.AddWebhookSubscriptions<TestWebhookSubscription>(buidler => ConfigureWebhookService(buidler))
 				.AddTestHttpClient(OnRequestAsync)
-				.AddLogging(logging => logging.AddXUnit(outputHelper))
+				.AddLogging(logging => logging.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Trace))
 				.BuildServiceProvider();
 		}
 


### PR DESCRIPTION
The code introduces configurations and data models to track the delivery of the webhooks

* New headers for the Webhook Trace ID and Webhook Delivery Attempt
* The logger of delivery results now get the event information as argument
* The MongoDB implementation of the logger stores also the event information