### PR TITLE
Making Dynamic Types Assemblies Static

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.idea/.idea.Deveel.Webhooks/.idea/.gitignore
+++ b/.idea/.idea.Deveel.Webhooks/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml
+/.idea.Deveel.Webhooks.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Deveel.Webhooks/.idea/encodings.xml
+++ b/.idea/.idea.Deveel.Webhooks/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/src/Deveel.Webhooks.Model/Deveel.Webhooks.Model.xml
+++ b/src/Deveel.Webhooks.Model/Deveel.Webhooks.Model.xml
@@ -43,7 +43,7 @@
         <member name="T:Deveel.Webhooks.IWebhook">
             <summary>
             Notifies the occurrence of an event
-            and trasports related data
+            and transports related data
             </summary>
         </member>
         <member name="P:Deveel.Webhooks.IWebhook.Id">

--- a/src/Deveel.Webhooks.Sender/Deveel.Webhooks.Sender.csproj
+++ b/src/Deveel.Webhooks.Sender/Deveel.Webhooks.Sender.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />

--- a/src/Deveel.Webhooks.Sender/Webhooks/Types/TypeCreator.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/Types/TypeCreator.cs
@@ -15,9 +15,18 @@
 using System.Reflection;
 using System.Reflection.Emit;
 
-namespace Deveel.Webhooks {
+namespace Deveel.Webhooks.Types {
 	static class TypeCreator {
 		private static int anonymousCounter = 0;
+
+		private static readonly ModuleBuilder TypesModule;
+
+		static TypeCreator() {
+			var assemblyName = new AssemblyName("Deveel.Webhooks.AnonymousTypes");
+			var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+			
+			TypesModule = assemblyBuilder.DefineDynamicModule("AnonymousTypes");
+		}
 
 		private static void CreateProperty(TypeBuilder typeBuilder, string propertyName, Type propertyType) {
 			var fieldBuilder = typeBuilder.DefineField($"_{propertyName}", propertyType, FieldAttributes.Private);
@@ -51,16 +60,13 @@ namespace Deveel.Webhooks {
 		private const string Namespace = "Deveel.Webhooks.Types";
 
 		private static Type? CreateType(Dictionary<string, Type> propertyTypes) {
-			var assemblyName = new AssemblyName("Deveel.Webhooks.AnonymousTypes");
-			var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-			var moduleBuilder = assemblyBuilder.DefineDynamicModule("AnonymousTypes");
 			var typeAtts = TypeAttributes.Public |
 				TypeAttributes.AnsiClass |
 				TypeAttributes.AutoClass |
 				TypeAttributes.AutoLayout |
 				TypeAttributes.BeforeFieldInit;
 
-			var typeBuilder = moduleBuilder.DefineType($"{Namespace}._Anonynous_{anonymousCounter++}", typeAtts);
+			var typeBuilder = TypesModule.DefineType($"{Namespace}._Anonynous_{anonymousCounter++}", typeAtts);
 
 			foreach (var propertyType in propertyTypes) {
 				string propertyName = propertyType.Key;

--- a/src/Deveel.Webhooks.Sender/Webhooks/WebhookJsonSerializerExtensions.cs
+++ b/src/Deveel.Webhooks.Sender/Webhooks/WebhookJsonSerializerExtensions.cs
@@ -15,6 +15,8 @@
 using System.Text;
 using System.Text.Json;
 
+using Deveel.Webhooks.Types;
+
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// Extends the <see cref="IWebhookJsonSerializer{TWebhook}"/> interface
@@ -81,7 +83,7 @@ namespace Deveel.Webhooks {
 			where TWebhook : class {
 
 			try {
-				Func<TWebhook, CancellationToken, Task<object?>> serialize = async (w, ct) => {
+				async Task<object?> Serialize(TWebhook w, CancellationToken ct) {
 					using var stream = new MemoryStream();
 					await serializer.SerializeAsync(stream, webhook, cancellationToken);
 					stream.Position = 0;
@@ -89,9 +91,9 @@ namespace Deveel.Webhooks {
 					var jsonElement = await JsonSerializer.DeserializeAsync<JsonElement>(stream, cancellationToken: cancellationToken);
 
 					return ToAnonymousType(jsonElement);
-				};
+				}
 
-				return await WebhookTypeCache.Default.GetOrCreateAsync(webhook, serialize, cancellationToken);
+				return await WebhookTypeCache.Default.GetOrCreateAsync(webhook, Serialize, cancellationToken);
 			} catch (Exception ex) {
 				throw new WebhookSerializationException("It was not possible to serialize the webhook", ex);
 			}

--- a/test/Deveel.Webhooks.DynamicLinq.XUnit/Webhooks/LinqEvaluatorTests.cs
+++ b/test/Deveel.Webhooks.DynamicLinq.XUnit/Webhooks/LinqEvaluatorTests.cs
@@ -75,6 +75,28 @@ namespace Deveel.Webhooks {
 		}
 
 		[Fact]
+		public async Task EvaluateComplexWebhook() {
+			var webhook = new TestWebhookWithComplexData {
+				Id = "123",
+				WebhookName = "test",
+				Data = new EventData {
+					Count = 10
+				},
+				EventType = new EventType {
+					StreamType = "test",
+					TypeName = "test",
+					Version = "1.0"
+				}
+			};
+
+			var evaluator = LinqWebhookFilterEvaluator<TestWebhookWithComplexData>.Default;
+			var filter = WebhookSubscriptionFilter.Create("linq", "data.count == 10 && event_type.type == \"test\"");
+			var result = await evaluator.MatchesAsync(filter, webhook, default);
+
+			Assert.True(result);
+		}
+
+		[Fact]
 		public async Task EvaluateNotLinq() {
 			await Assert.ThrowsAsync<ArgumentException>(() => evaluator.MatchesAsync(WebhookSubscriptionFilter.Create("json", "event_name == \"data.created\""), new TestWebhook()));
 		}
@@ -88,6 +110,36 @@ namespace Deveel.Webhooks {
 
 			[JsonExtensionData]
 			public IDictionary<string, JsonElement>? Data { get; set; }
+		}
+
+		class TestWebhookWithComplexData {
+			[JsonPropertyName("id")]
+			public string Id { get; set; }
+			
+			[JsonPropertyName("name")]
+			public string WebhookName { get; set; }
+			
+			[JsonPropertyName(("data"))]
+			public EventData Data { get; set; }
+			
+			[JsonPropertyName("event_type")]
+			public EventType EventType { get; set; }
+		}
+
+		class EventData {
+			[JsonPropertyName("count")] 
+			public int Count { get; set; }
+		}
+
+		class EventType {
+			[JsonPropertyName("stream_type")]
+			public string StreamType { get; set; }
+			
+			[JsonPropertyName("type")]
+			public string TypeName { get; set; }
+			
+			[JsonPropertyName("version")]
+			public string Version { get; set; }
 		}
 	}
 }

--- a/test/Deveel.Webhooks.MongoDb.XUnit/Deveel.Webhooks.MongoDb.XUnit.csproj
+++ b/test/Deveel.Webhooks.MongoDb.XUnit/Deveel.Webhooks.MongoDb.XUnit.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="EphemeralMongo6" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoDbWebhookTestBase.cs
+++ b/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoDbWebhookTestBase.cs
@@ -18,9 +18,6 @@ using Deveel.Util;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Driver;
 

--- a/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoTestCluster.cs
+++ b/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoTestCluster.cs
@@ -12,22 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.Extensions.Logging.Abstractions;
+using System.Text;
 
-using Mongo2Go;
+using EphemeralMongo;
 
 namespace Deveel.Webhooks {
 	public class MongoTestCluster : IDisposable {
-		private readonly MongoDbRunner mongo;
+		private readonly IMongoRunner mongo;
 
 		public MongoTestCluster() {
-			mongo = MongoDbRunner.Start(logger: NullLogger.Instance);
+			mongo = MongoRunner.Run(new MongoRunnerOptions {
+				KillMongoProcessesWhenCurrentProcessExits = true
+			});
+
+			var connString = new StringBuilder(mongo.ConnectionString);
+			if (!connString[^1].Equals('/'))
+				connString.Append('/');
+			
+			ConnectionString = connString.ToString();
 		}
 
-		public string ConnectionString => mongo.ConnectionString;
+		public string ConnectionString { get; }
 
 		public void Dispose() {
-			mongo.Dispose();
+			mongo?.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
Changing the logic of creation of the webhook objects for filter evaluation

* The dynamic assembly is now a static field, initialized only once
* The dyamic module containing the compiled anonymous types is now static