### PR TITLE
Webhook Subscription Resolution Changes

### DIFF
--- a/Deveel.Webhooks.sln
+++ b/Deveel.Webhooks.sln
@@ -75,7 +75,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Webhooks.XUnit", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Webhooks.Receiver.TestApi", "test\Deveel.Webhooks.Receiver.TestApi\Deveel.Webhooks.Receiver.TestApi.csproj", "{4942C858-277D-438D-B822-92055B8E8DF7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Webhooks.DeliveryResultLogging.Tests", "test\Deveel.Webhooks.DeliveryResultLogging.Tests\Deveel.Webhooks.DeliveryResultLogging.Tests.csproj", "{DDD9A4CB-AA5E-4C0B-87F3-CDC24F6A8DA0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Webhooks.DeliveryResultLogging.Tests", "test\Deveel.Webhooks.DeliveryResultLogging.Tests\Deveel.Webhooks.DeliveryResultLogging.Tests.csproj", "{DDD9A4CB-AA5E-4C0B-87F3-CDC24F6A8DA0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Deveel.Webhooks.Receiver.AspNetCore/Json/UnixTimeSecondsConverter.cs
+++ b/src/Deveel.Webhooks.Receiver.AspNetCore/Json/UnixTimeSecondsConverter.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 
 namespace Deveel.Json {
 	/// <summary>

--- a/src/Deveel.Webhooks.Sender/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Webhooks.Sender/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ namespace Deveel {
 			var builder = new WebhookSenderBuilder<TWebhook>(services);
 
 			services.TryAddSingleton(builder);
+			services.AddOptions<WebhookSenderOptions<TWebhook>>();
 
 			return builder;
 		}

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookNotifierBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookNotifierBuilderExtensions.cs
@@ -1,18 +1,51 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Deveel.Data;
+﻿using Deveel.Data;
 
 namespace Deveel.Webhooks {
+	/// <summary>
+	/// Extends the <see cref="WebhookNotifierBuilder{TWebhook}"/> to add Entity Framework
+	/// support for the delivery results entities.
+	/// </summary>
 	public static class WebhookNotifierBuilderExtensions {
+		/// <summary>
+		/// Configures the builder to use the default entity framework delivery 
+		/// results support.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook to be used in the notifier.
+		/// </typeparam>
+		/// <param name="builder">
+		/// The builder to configure.
+		/// </param>
+		/// <returns>
+		/// Returns the same builder instance for chaining calls.
+		/// </returns>
 		public static WebhookNotifierBuilder<TWebhook> UseEntityFrameworkDeliveryResults<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder)
 			where TWebhook : class
 			=> builder.UseEntityFrameworkDeliveryResults<TWebhook>(typeof(DbWebhookDeliveryResult));
 
-
+		/// <summary>
+		/// Configures the builder to use the default entity framework delivery 
+		/// results support.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook to be used in the notifier.
+		/// </typeparam>
+		/// <param name="builder">
+		/// The builder to configure.
+		/// </param>
+		/// <param name="resultType">
+		/// The type of the delivery result entity to be used.
+		/// </param>
+		/// <returns>
+		/// Returns the same builder instance for chaining calls.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown when the given <paramref name="resultType"/> is <c>null</c>.
+		/// </exception>
+		/// <exception cref="ArgumentException">
+		/// Thrown when the given <paramref name="resultType"/> is not a valid
+		/// type for the delivery result entity.
+		/// </exception>
 		public static WebhookNotifierBuilder<TWebhook> UseEntityFrameworkDeliveryResults<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder, Type resultType)
 			where TWebhook : class {
 			ArgumentNullException.ThrowIfNull(resultType, nameof(resultType));

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookNotifierBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookNotifierBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Deveel.Data;
+
+namespace Deveel.Webhooks {
+	public static class WebhookNotifierBuilderExtensions {
+		public static WebhookNotifierBuilder<TWebhook> UseEntityFrameworkDeliveryResults<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder)
+			where TWebhook : class
+			=> builder.UseEntityFrameworkDeliveryResults<TWebhook>(typeof(DbWebhookDeliveryResult));
+
+
+		public static WebhookNotifierBuilder<TWebhook> UseEntityFrameworkDeliveryResults<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder, Type resultType)
+			where TWebhook : class {
+			ArgumentNullException.ThrowIfNull(resultType, nameof(resultType));
+
+			if (!typeof(DbWebhookDeliveryResult).IsAssignableFrom(resultType))
+				throw new ArgumentException($"The given type '{resultType}' is not a valid result type");
+
+			var resultStoreType = typeof(EntityWebhookDeliveryResultRepository<>).MakeGenericType(resultType);
+			builder.Services.AddRepository(resultStoreType);
+
+			if (resultType == typeof(DbWebhookDeliveryResult))
+				builder.Services.AddRepository<EntityWebhookDeliveryResultRepository>();
+
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookSubscriptionBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookSubscriptionBuilderExtensions.cs
@@ -24,9 +24,6 @@ namespace Deveel.Webhooks {
 		/// <typeparam name="TSubscription">
 		/// The type of the <see cref="DbWebhookSubscription"/> entity to use
 		/// </typeparam>
-		/// <typeparam name="TResult">
-		/// The type of the <see cref="DbWebhookDeliveryResult"/> entity to use
-		/// </typeparam>
 		/// <param name="builder">
 		/// The instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/> to
 		/// extend with the Entity Framework storage system.
@@ -35,60 +32,15 @@ namespace Deveel.Webhooks {
 		/// Returns an instance of <see cref="EntityWebhookStorageBuilder{TSubscription}"/>
 		/// that can be used to configure the storage system.
 		/// </returns>
-        public static EntityWebhookStorageBuilder<TSubscription> UseEntityFramework<TSubscription, TResult>(this WebhookSubscriptionBuilder<TSubscription> builder)
+        public static EntityWebhookStorageBuilder<TSubscription> UseEntityFramework<TSubscription>(this WebhookSubscriptionBuilder<TSubscription> builder)
             where TSubscription : DbWebhookSubscription
-			where TResult : DbWebhookDeliveryResult {
-            return new EntityWebhookStorageBuilder<TSubscription>(builder, typeof(TResult));
-        }
+			=> new EntityWebhookStorageBuilder<TSubscription>(builder);
 
 		/// <summary>
 		/// Instructs the builder to use Entity Framework as the storage system
 		/// </summary>
 		/// <typeparam name="TSubscription">
 		/// The type of the <see cref="DbWebhookSubscription"/> entity to use
-		/// </typeparam>
-		/// <param name="builder">
-		/// The instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/> to
-		/// extend with the Entity Framework storage system.
-		/// </param>
-		/// <returns>
-		/// Returns an instance of <see cref="EntityWebhookStorageBuilder{TSubscription}"/>
-		/// that can be used to configure the storage system.
-		/// </returns>
-		public static EntityWebhookStorageBuilder<TSubscription> UseEntityFramework<TSubscription>(this WebhookSubscriptionBuilder<TSubscription> builder)
-			where TSubscription : DbWebhookSubscription
-			=> UseEntityFramework<TSubscription, DbWebhookDeliveryResult>(builder);
-
-		/// <summary>
-		/// Instructs the builder to use Entity Framework as the storage system
-		/// </summary>
-		/// <typeparam name="TSubscription">
-		/// The type of the <see cref="DbWebhookSubscription"/> entity to use
-		/// </typeparam>
-		/// <param name="builder">
-		/// The instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/> to
-		/// extend with the Entity Framework storage system.
-		/// </param>
-		/// <param name="configure">
-		/// An action that receives an instance of <see cref="EntityWebhookStorageBuilder{TSubscription}"/>
-		/// to configure the storage system.
-		/// </param>
-		/// <returns>
-		/// Returns the same instance of <see cref="WebhookSubscriptionBuilder{TSubscription}"/>
-		/// as the input, to allow chaining of calls.
-		/// </returns>
-        public static WebhookSubscriptionBuilder<TSubscription> UseEntityFramework<TSubscription>(this WebhookSubscriptionBuilder<TSubscription> builder, Action<EntityWebhookStorageBuilder<TSubscription>> configure)
-            where TSubscription : DbWebhookSubscription
-			=> UseEntityFramework<TSubscription, DbWebhookDeliveryResult>(builder, configure);
-
-		/// <summary>
-		/// Instructs the builder to use Entity Framework as the storage system
-		/// </summary>
-		/// <typeparam name="TSubscription">
-		/// The type of the <see cref="DbWebhookSubscription"/> entity to use
-		/// </typeparam>
-		/// <typeparam name="TResult">
-		/// The type of the <see cref="DbWebhookDeliveryResult"/> entity to use
 		/// </typeparam>
 		/// <param name="builder">
 		/// The instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/> to
@@ -102,9 +54,8 @@ namespace Deveel.Webhooks {
 		/// Returns the same instance of <see cref="WebhookSubscriptionBuilder{TSubscription}"/>
 		/// as the input, to allow chaining of calls.
 		/// </returns>
-		public static WebhookSubscriptionBuilder<TSubscription> UseEntityFramework<TSubscription, TResult>(this WebhookSubscriptionBuilder<TSubscription> builder, Action<EntityWebhookStorageBuilder<TSubscription>> configure)
-			where TSubscription : DbWebhookSubscription
-			where TResult : DbWebhookDeliveryResult {
+		public static WebhookSubscriptionBuilder<TSubscription> UseEntityFramework<TSubscription>(this WebhookSubscriptionBuilder<TSubscription> builder, Action<EntityWebhookStorageBuilder<TSubscription>> configure)
+			where TSubscription : DbWebhookSubscription {
 			var storageBuilder = builder.UseEntityFramework();
 			configure(storageBuilder);
 			return builder;

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
@@ -186,41 +186,6 @@ namespace Deveel.Webhooks {
 			return this;
 		}
 
-		/// <summary>
-		/// Registers an implementation of <see cref="IWebhookDeliveryResultLogger{TWebhook}"/>
-		/// that is using MongoDB as the storage for the webhook delivery results.
-		/// </summary>
-		/// <typeparam name="TWebhook">
-		/// The type of the webhook that is being delivered.
-		/// </typeparam>
-		/// <typeparam name="TResult">
-		/// The type of the webhook delivery result that is being logged.
-		/// </typeparam>
-		/// <returns>
-		/// Returns the current instance of the builder for chaining.
-		/// </returns>
-		public MongoDbWebhookStorageBuilder<TSubscription> UseDeliveryResultLogger<TWebhook, TResult>()
-			where TWebhook : class
-			where TResult : MongoWebhookDeliveryResult, new() {
-
-			Services.AddTransient<IWebhookDeliveryResultLogger<TWebhook>, MongoDbWebhookDeliveryResultLogger<TWebhook, TResult>>();
-
-			return this;
-		}
-
-		/// <summary>
-		/// Registers an implementation of <see cref="IWebhookDeliveryResultLogger{TWebhook}"/>
-		/// that is using MongoDB as the storage for the webhook delivery results.
-		/// </summary>
-		/// <typeparam name="TWebhook">
-		/// The type of the webhook that is being delivered.
-		/// </typeparam>
-		/// <returns>
-		/// Returns the current instance of the builder for chaining.
-		/// </returns>
-		public MongoDbWebhookStorageBuilder<TSubscription> UseDeliveryResultLogger<TWebhook>()
-			where TWebhook : class
-			=> UseDeliveryResultLogger<TWebhook, MongoWebhookDeliveryResult>();
 
 		/// <summary>
 		/// Registers a service that is used to convert the webhook

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
@@ -98,7 +98,7 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns the current instance of the builder for chaining.
 		/// </returns>
-		public MongoDbWebhookStorageBuilder<TSubscription> WithTenantConnectionString(Action<ITenantInfo?, MongoConnectionBuilder> configure) {
+		public MongoDbWebhookStorageBuilder<TSubscription> WithTenantConnection(Action<ITenantInfo?, MongoConnectionBuilder> configure) {
 			Services.AddMongoDbContext<MongoDbWebhookContext>(configure);
 
 			return this;
@@ -161,31 +161,9 @@ namespace Deveel.Webhooks {
 			Services.RemoveAll<IWebhookSubscriptionRepository<TSubscription>>();
 
 			Services.AddRepository<TRepository>();
-			//Services.AddScoped<IWebhookSubscriptionStore<MongoWebhookSubscription>, TStore>();
-			//Services.AddScoped<TStore>();
 
 			return this;
 		}
-
-		/// <summary>
-		/// Registers the given type of storage to be used for
-		/// storing the webhook delivery results.
-		/// </summary>
-		/// <typeparam name="TRepository">
-		/// The type of the storage to use for storing the webhook delivery results,
-		/// derived from <see cref="MongoDbWebhookDeliveryResultRepository"/>.
-		/// </typeparam>
-		/// <returns>
-		/// Returns the current instance of the builder for chaining.
-		/// </returns>
-		public MongoDbWebhookStorageBuilder<TSubscription> UseDeliveryResultRepository<TRepository>()
-			where TRepository : MongoDbWebhookDeliveryResultRepository {
-			Services.AddRepository<TRepository>();
-			// Services.AddScoped<IWebhookDeliveryResultStore<MongoWebhookDeliveryResult>, TStore>();
-
-			return this;
-		}
-
 
 		/// <summary>
 		/// Registers a service that is used to convert the webhook

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/WebhookNotifierBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/WebhookNotifierBuilderExtensions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Deveel.Webhooks {
     /// <summary>
     /// Provides extensions to the <see cref="WebhookNotifierBuilder{TWebhook}"/>
@@ -54,9 +56,43 @@ namespace Deveel.Webhooks {
 		/// </returns>
 		public static WebhookNotifierBuilder<TWebhook> UseMongoTenantSubscriptionResolver<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder)
 			where TWebhook : class {
-			return builder
-				.UseDefaultTenantSubscriptionResolver(typeof(MongoWebhookSubscription));
+			return builder.UseDefaultTenantSubscriptionResolver(typeof(MongoWebhookSubscription));
 		}
 
+		/// <summary>
+		/// Registers an implementation of <see cref="IWebhookDeliveryResultLogger{TWebhook}"/>
+		/// that is using MongoDB as the storage for the webhook delivery results.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook that is being delivered.
+		/// </typeparam>
+		/// <typeparam name="TResult">
+		/// The type of the webhook delivery result that is being logged.
+		/// </typeparam>
+		/// <returns>
+		/// Returns the current instance of the builder for chaining.
+		/// </returns>
+		public static WebhookNotifierBuilder<TWebhook> UseMongoDeliveryResultLogger<TWebhook, TResult>(this WebhookNotifierBuilder<TWebhook> builder)
+			where TWebhook : class
+			where TResult : MongoWebhookDeliveryResult, new() {
+
+			builder.Services.AddTransient<IWebhookDeliveryResultLogger<TWebhook>, MongoDbWebhookDeliveryResultLogger<TWebhook, TResult>>();
+
+			return builder;
+		}
+
+		/// <summary>
+		/// Registers an implementation of <see cref="IWebhookDeliveryResultLogger{TWebhook}"/>
+		/// that is using MongoDB as the storage for the webhook delivery results.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook that is being delivered.
+		/// </typeparam>
+		/// <returns>
+		/// Returns the current instance of the builder for chaining.
+		/// </returns>
+		public static WebhookNotifierBuilder<TWebhook> UseMongoDeliveryResultLogger<TWebhook>(this WebhookNotifierBuilder<TWebhook> builder)
+			where TWebhook : class
+			=> builder.UseMongoDeliveryResultLogger<TWebhook, MongoWebhookDeliveryResult>();
 	}
 }

--- a/src/Deveel.Webhooks.Service/Webhooks/IWebhookSubscriptionValidator.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/IWebhookSubscriptionValidator.cs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Deveel.Data;
 
 namespace Deveel.Webhooks {

--- a/src/Deveel.Webhooks.Service/Webhooks/WebhookNotifierBuilderExtensions.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/WebhookNotifierBuilderExtensions.cs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Deveel.Webhooks {
@@ -63,6 +57,5 @@ namespace Deveel.Webhooks {
 			var resolverType = typeof(WebhookSubscriptionResolver<>).MakeGenericType(subscriptionType);
 			return builder.UseSubscriptionResolver(resolverType, lifetime);
 		}
-
 	}
 }

--- a/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionBuilder.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionBuilder.cs
@@ -14,6 +14,8 @@
 
 using System;
 
+using Deveel.Data;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -57,25 +59,25 @@ namespace Deveel.Webhooks {
 			// Services.TryAddScoped<ITenantWebhookSubscriptionResolver, TenantWebhookSubscriptionResolver<TSubscription>>();
 		}
 
-		/// <summary>
-		/// Adds the notification capabilities to the service.
-		/// </summary>
-		/// <typeparam name="TWebhook">
-		/// The type of the webhook that is notified the subscribers.
-		/// </typeparam>
-		/// <param name="configure">
-		/// A callback that is used to configure the webhook notifier.
-		/// </param>
-		/// <returns>
-		/// Returns this instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/>.
-		/// </returns>
-		/// <seealso cref="ITenantWebhookNotifier{TWebhook}"/>
-		public WebhookSubscriptionBuilder<TSubscription> UseNotifier<TWebhook>(Action<WebhookNotifierBuilder<TWebhook>> configure)
-			where TWebhook : class, IWebhook {
-			Services.AddWebhookNotifier(configure);
+		///// <summary>
+		///// Adds the notification capabilities to the service.
+		///// </summary>
+		///// <typeparam name="TWebhook">
+		///// The type of the webhook that is notified the subscribers.
+		///// </typeparam>
+		///// <param name="configure">
+		///// A callback that is used to configure the webhook notifier.
+		///// </param>
+		///// <returns>
+		///// Returns this instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/>.
+		///// </returns>
+		///// <seealso cref="ITenantWebhookNotifier{TWebhook}"/>
+		//public WebhookSubscriptionBuilder<TSubscription> UseNotifier<TWebhook>(Action<WebhookNotifierBuilder> configure)
+		//	where TWebhook : class, IWebhook {
+		//	Services.AddWebhookNotifier<TWebhook>(configure);
 
-			return this;
-		}
+		//	return this;
+		//}
 
 		/// <summary>
 		/// Registers a custom <see cref="WebhookSubscriptionManager{TSubscription}"/>
@@ -92,6 +94,9 @@ namespace Deveel.Webhooks {
 		/// </returns>
 		public WebhookSubscriptionBuilder<TSubscription> UseSubscriptionManager<TManager>(ServiceLifetime lifetime = ServiceLifetime.Scoped)
 			where TManager : WebhookSubscriptionManager<TSubscription> {
+
+			Services.RemoveAll<EntityManager<TSubscription>>();
+			Services.RemoveAll<WebhookSubscriptionManager<TSubscription>>();
 
 			Services.TryAdd(new ServiceDescriptor(typeof(WebhookSubscriptionManager<TSubscription>), typeof(TManager), lifetime));
 

--- a/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionBuilder.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionBuilder.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 using Deveel.Data;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -56,28 +54,9 @@ namespace Deveel.Webhooks {
 			Services.TryAddSingleton<IWebhookSubscriptionValidator<TSubscription>, WebhookSubscriptionValidator<TSubscription>>();
 
 			Services.TryAddScoped<IWebhookSubscriptionResolver, WebhookSubscriptionResolver<TSubscription>>();
+			Services.TryAddScoped<WebhookSubscriptionResolver<TSubscription>>();
 			// Services.TryAddScoped<ITenantWebhookSubscriptionResolver, TenantWebhookSubscriptionResolver<TSubscription>>();
 		}
-
-		///// <summary>
-		///// Adds the notification capabilities to the service.
-		///// </summary>
-		///// <typeparam name="TWebhook">
-		///// The type of the webhook that is notified the subscribers.
-		///// </typeparam>
-		///// <param name="configure">
-		///// A callback that is used to configure the webhook notifier.
-		///// </param>
-		///// <returns>
-		///// Returns this instance of the <see cref="WebhookSubscriptionBuilder{TSubscription}"/>.
-		///// </returns>
-		///// <seealso cref="ITenantWebhookNotifier{TWebhook}"/>
-		//public WebhookSubscriptionBuilder<TSubscription> UseNotifier<TWebhook>(Action<WebhookNotifierBuilder> configure)
-		//	where TWebhook : class, IWebhook {
-		//	Services.AddWebhookNotifier<TWebhook>(configure);
-
-		//	return this;
-		//}
 
 		/// <summary>
 		/// Registers a custom <see cref="WebhookSubscriptionManager{TSubscription}"/>
@@ -129,8 +108,8 @@ namespace Deveel.Webhooks {
 		/// </returns>
 		public WebhookSubscriptionBuilder<TSubscription> AddSubscriptionValidator<TValidator>(ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TValidator : class, IWebhookSubscriptionValidator<TSubscription> {
-			Services.Add(new ServiceDescriptor(typeof(IWebhookSubscriptionValidator<TSubscription>), typeof(TValidator), lifetime));
-			Services.Add(new ServiceDescriptor(typeof(TValidator), typeof(TValidator), lifetime));
+
+			Services.AddEntityValidator<TValidator>(lifetime);
 
 			return this;
 		}

--- a/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionResolver.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionResolver.cs
@@ -27,7 +27,7 @@ namespace Deveel.Webhooks {
 	/// </typeparam>
 	public class WebhookSubscriptionResolver<TSubscription> : IWebhookSubscriptionResolver
 		where TSubscription : class, IWebhookSubscription {
-		private readonly IWebhookSubscriptionRepository<TSubscription> store;
+		private readonly IWebhookSubscriptionRepository<TSubscription> repository;
 		private readonly IWebhookSubscriptionCache? cache;
 		private ILogger logger;
 
@@ -35,7 +35,7 @@ namespace Deveel.Webhooks {
 		/// Constructs a <see cref="WebhookSubscriptionResolver{TSubscription}"/>
 		/// backed by a given store.
 		/// </summary>
-		/// <param name="store">
+		/// <param name="repository">
 		/// The store to be used to retrieve the subscriptions.
 		/// </param>
 		/// <param name="cache">
@@ -46,10 +46,10 @@ namespace Deveel.Webhooks {
 		/// An optional logger to be used to log the operations.
 		/// </param>
 		public WebhookSubscriptionResolver(
-			IWebhookSubscriptionRepository<TSubscription> store,
+			IWebhookSubscriptionRepository<TSubscription> repository,
 			IWebhookSubscriptionCache? cache = null,
 			ILogger<TenantWebhookSubscriptionResolver<TSubscription>>? logger = null) {
-			this.store = store;
+			this.repository = repository;
 			this.cache = cache;
 			this.logger = logger ?? NullLogger<TenantWebhookSubscriptionResolver<TSubscription>>.Instance;
 		}
@@ -78,7 +78,7 @@ namespace Deveel.Webhooks {
 				if (list == null) {
 					logger.LogTrace("No webhook subscriptions to event {EventType} of tenant {TenantId} were found in cache", eventType);
 
-					var result = await store.GetByEventTypeAsync(eventType, activeOnly, cancellationToken);
+					var result = await repository.GetByEventTypeAsync(eventType, activeOnly, cancellationToken);
 					list = result.Cast<IWebhookSubscription>().ToList();
 				}
 

--- a/src/Deveel.Webhooks/Webhooks/IWebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookNotifier.cs
@@ -44,6 +44,6 @@ namespace Deveel.Webhooks {
 		/// Returns an object that describes the aggregated final result of 
 		/// the notification process executed.
 		/// </returns>
-		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventInfo eventInfo, CancellationToken cancellationToken);
+		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventInfo eventInfo, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -54,8 +49,15 @@ namespace Deveel.Webhooks {
 
 		private void RegisterDefaultServices() {
 			Services.TryAddScoped<IWebhookNotifier<TWebhook>, WebhookNotifier<TWebhook>>();
-
+			Services.TryAddScoped<WebhookNotifier<TWebhook>>();
 			Services.TryAddScoped<IWebhookSender<TWebhook>, WebhookSender<TWebhook>>();
+			Services.TryAddScoped<WebhookSender<TWebhook>>();
+
+			if (typeof(Webhook).IsAssignableFrom(typeof(TWebhook))) {
+				var factoryType = typeof(DefaultWebhookFactory<>).MakeGenericType(typeof(TWebhook));
+				Services.TryAddSingleton(typeof(IWebhookFactory<TWebhook>), factoryType);
+				Services.TryAddSingleton(factoryType);
+			}
 
 			// TODO: register the default filter evaluator
 		}
@@ -184,8 +186,8 @@ namespace Deveel.Webhooks {
 
 			Services.RemoveAll<IWebhookFactory<TWebhook>>();
 
-			Services.Add(new ServiceDescriptor(typeof(IWebhookFactory<TWebhook>), typeof(TFactory), lifetime));
-			Services.TryAdd(new ServiceDescriptor(typeof(TFactory), typeof(TFactory), lifetime));
+			Services.TryAdd(new ServiceDescriptor(typeof(IWebhookFactory<TWebhook>), typeof(TFactory), lifetime));
+			Services.Add(new ServiceDescriptor(typeof(TFactory), typeof(TFactory), lifetime));
 
 			return this;
 		}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntitySubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntitySubscriptionResolverTests.cs
@@ -1,0 +1,78 @@
+﻿using Deveel.Data;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit.Abstractions;
+
+using static System.Formats.Asn1.AsnWriter;
+
+namespace Deveel.Webhooks {
+	public class EntitySubscriptionResolverTests : EntityWebhookTestBase {
+		public EntitySubscriptionResolverTests(SqliteTestDatabase sqlite, ITestOutputHelper outputHelper) 
+			: base(sqlite, outputHelper) {
+		}
+
+		protected IList<DbWebhookSubscription> Subscriptions { get; private set; }
+
+		protected IRepository<DbWebhookSubscription> Repository => Services.GetRequiredService<IRepository<DbWebhookSubscription>>();
+
+		public IWebhookSubscriptionResolver Resolver => Services.GetRequiredService<IWebhookSubscriptionResolver>();
+
+		public override async Task InitializeAsync() {
+			await base.InitializeAsync();
+
+			Subscriptions = new DbWebhookSubscriptionFaker().Generate(102);
+
+			await Repository.AddRangeAsync(Subscriptions);
+		}
+
+		public override async Task DisposeAsync() {
+			await Repository.RemoveRangeAsync(Subscriptions);
+
+			await base.DisposeAsync();
+		}
+
+		private DbWebhookSubscription Random(Func<DbWebhookSubscription, bool>? predicate = null, int maxRetries = 100) {
+			while (maxRetries-- >= 0) {
+				var index = System.Random.Shared.Next(0, Subscriptions.Count - 1);
+				var subscription = Subscriptions[index];
+
+				if (predicate == null || predicate(subscription))
+					return subscription;
+			}
+
+			throw new InvalidOperationException("Could not find a random subscription");
+		}
+
+		[Fact]
+		public async Task ResolveActiveSubscriptions() {
+			var subscription = Random(x => x.Events.Any());
+			var eventType = subscription.Events[0].EventType;
+
+			var subCount = Subscriptions.Count(x => x.Events.Any(y => y.EventType == eventType) &&
+											   x.Status == WebhookSubscriptionStatus.Active);
+
+			var subscriptions = await Resolver.ResolveSubscriptionsAsync(eventType, true, CancellationToken.None);
+
+			Assert.NotNull(subscriptions);
+			Assert.NotEmpty(subscriptions);
+
+			Assert.Equal(subCount, subscriptions.Count);
+		}
+
+		[Fact]
+		public async Task ResolveAllSubscriptions() {
+			var subscription = Random(x => x.Events.Any());
+			var eventType = subscription.Events[0].EventType;
+
+			var subCount = Subscriptions.Count(x => x.Events.Any(y => y.EventType == eventType));
+
+			var subscriptions = await Resolver.ResolveSubscriptionsAsync(eventType, false, CancellationToken.None);
+
+			Assert.NotNull(subscriptions);
+			Assert.NotEmpty(subscriptions);
+
+			Assert.Equal(subCount, subscriptions.Count);
+		}
+	}
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookTestBase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookTestBase.cs
@@ -31,6 +31,8 @@ namespace Deveel.Webhooks {
                 .AddTestHttpClient(OnRequestAsync)
                 .AddLogging(logging => logging.AddXUnit(outputHelper));
 
+			services.AddWebhookNotifier<Webhook>(builder => builder.UseEntityFrameworkDeliveryResults());
+
             return services.BuildServiceProvider();
         }
 

--- a/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoDbWebhookTestBase.cs
+++ b/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoDbWebhookTestBase.cs
@@ -30,6 +30,9 @@ namespace Deveel.Webhooks {
 
 		protected MongoDbWebhookTestBase(MongoTestDatabase mongo, ITestOutputHelper outputHelper) {
 			this.mongo = mongo;
+
+			Client = new MongoClient(mongo.ConnectionString);
+
 			Services = BuildServiceProvider(outputHelper);
 			Scope = Services.CreateScope();
 		}
@@ -40,17 +43,16 @@ namespace Deveel.Webhooks {
 
 		protected string ConnectionString => mongo.ConnectionString;
 
+		protected MongoClient Client { get; }
+
 		public virtual async Task InitializeAsync() {
-			var client = new MongoClient(ConnectionString);
-			await client.GetDatabase("webhooks").CreateCollectionAsync(MongoDbWebhookStorageConstants.SubscriptionCollectionName);
-			await client.GetDatabase("webhooks").CreateCollectionAsync(MongoDbWebhookStorageConstants.DeliveryResultsCollectionName);
+			await Client.GetDatabase("webhooks").CreateCollectionAsync(MongoDbWebhookStorageConstants.SubscriptionCollectionName);
+			await Client.GetDatabase("webhooks").CreateCollectionAsync(MongoDbWebhookStorageConstants.DeliveryResultsCollectionName);
 		}
 
 		public virtual async Task DisposeAsync() {
-			var client = new MongoClient(ConnectionString);
-
-			await client.GetDatabase("webhooks").DropCollectionAsync(MongoDbWebhookStorageConstants.SubscriptionCollectionName);
-			await client.GetDatabase("webhooks").DropCollectionAsync(MongoDbWebhookStorageConstants.DeliveryResultsCollectionName);
+			await Client.GetDatabase("webhooks").DropCollectionAsync(MongoDbWebhookStorageConstants.SubscriptionCollectionName);
+			await Client.GetDatabase("webhooks").DropCollectionAsync(MongoDbWebhookStorageConstants.DeliveryResultsCollectionName);
 
 			Scope.Dispose();
 		}

--- a/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoSubsctiptionResolverTests.cs
+++ b/test/Deveel.Webhooks.MongoDb.XUnit/Webhooks/MongoSubsctiptionResolverTests.cs
@@ -1,0 +1,78 @@
+﻿using Deveel.Data;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MongoDB.Driver;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks {
+	public class MongoSubsctiptionResolverTests : MongoDbWebhookTestBase {
+		public MongoSubsctiptionResolverTests(MongoTestDatabase mongo, ITestOutputHelper outputHelper) 
+			: base(mongo, outputHelper) {
+		}
+
+		protected IList<MongoWebhookSubscription> Subscriptions { get; private set; }
+
+		protected IRepository<MongoWebhookSubscription> Repository => Scope.ServiceProvider.GetRequiredService<IRepository<MongoWebhookSubscription>>();
+
+		public IWebhookSubscriptionResolver Resolver => Scope.ServiceProvider.GetRequiredService<IWebhookSubscriptionResolver>();
+
+		public override async Task InitializeAsync() {
+			await base.InitializeAsync();
+
+			Subscriptions = new MongoWebhookSubscriptionFaker().Generate(102);
+
+			await Repository.AddRangeAsync(Subscriptions);
+		}
+
+		public override async Task DisposeAsync() {
+			await Repository.RemoveRangeAsync(Subscriptions);
+
+			await base.DisposeAsync();
+		}
+
+		private MongoWebhookSubscription Random(Func<MongoWebhookSubscription, bool>? predicate = null, int maxRetries = 100) {
+			while(maxRetries-- >= 0) {
+				var index = System.Random.Shared.Next(0, Subscriptions.Count - 1);
+				var subscription = Subscriptions[index];
+
+				if (predicate == null || predicate(subscription))
+					return subscription;
+			}
+
+			throw new InvalidOperationException("Could not find a random subscription");
+		}
+
+		[Fact]
+		public async Task ResolveActiveSubscriptions() {
+			var subscription = Random(x => x.EventTypes.Any());
+			var eventType = subscription.EventTypes[0];
+
+			var subCount = Subscriptions.Count(x => x.EventTypes.Any(y => y == eventType) && 
+											   x.Status == WebhookSubscriptionStatus.Active);
+
+			var subscriptions = await Resolver.ResolveSubscriptionsAsync(eventType, true, CancellationToken.None);
+
+			Assert.NotNull(subscriptions);
+			Assert.NotEmpty(subscriptions);
+
+			Assert.Equal(subCount, subscriptions.Count);
+		}
+
+		[Fact]
+		public async Task ResolveAllSubscriptions() {
+			var subscription = Random(x => x.EventTypes.Any());
+			var eventType = subscription.EventTypes[0];
+
+			var subCount = Subscriptions.Count(x => x.EventTypes.Any(y => y == eventType));
+
+			var subscriptions = await Resolver.ResolveSubscriptionsAsync(eventType, false, CancellationToken.None);
+
+			Assert.NotNull(subscriptions);
+			Assert.NotEmpty(subscriptions);
+
+			Assert.Equal(subCount, subscriptions.Count);
+		}
+	}
+}

--- a/test/Deveel.Webhooks.Sender.XUnit/Deveel.Webhooks.Sender.XUnit.csproj
+++ b/test/Deveel.Webhooks.Sender.XUnit/Deveel.Webhooks.Sender.XUnit.csproj
@@ -10,6 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" Condition="'$(TargetFramework)' == 'net6.0'"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Webhooks.Sender\Deveel.Webhooks.Sender.csproj" />
   </ItemGroup>
 

--- a/test/Deveel.Webhooks.Sender.XUnit/Webhooks/ServiceRegistrationTests.cs
+++ b/test/Deveel.Webhooks.Sender.XUnit/Webhooks/ServiceRegistrationTests.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Webhooks {
+	public static class ServiceRegistrationTests {
+		[Fact]
+		public static void AddSenderWithDefaults() {
+			var services = new ServiceCollection();
+
+			services.AddWebhookSender<Webhook>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<IOptions<WebhookSenderOptions<Webhook>>>());
+			Assert.NotNull(provider.GetService<IWebhookSender<Webhook>>());
+			Assert.NotNull(provider.GetService<WebhookSender<Webhook>>());
+		}
+
+		[Fact]
+		public static void AddSenderWithOptions() {
+			var services = new ServiceCollection();
+
+			services.AddWebhookSender<Webhook>(options => {
+				options.Retry.MaxRetries = 3;
+				options.DefaultFormat = WebhookFormat.Xml;
+			});
+
+			var provider = services.BuildServiceProvider();
+
+			var options = provider.GetRequiredService<IOptions<WebhookSenderOptions<Webhook>>>();
+
+			Assert.NotNull(provider.GetService<IWebhookSender<Webhook>>());
+			Assert.NotNull(provider.GetService<WebhookSender<Webhook>>());
+
+			Assert.Equal(3, options.Value.Retry.MaxRetries);
+			Assert.Equal(WebhookFormat.Xml, options.Value.DefaultFormat);
+		}
+
+		[Fact]
+		public static void AddSenderWithConfiguration() {
+			var services = new ServiceCollection();
+
+			var configuration = new ConfigurationBuilder()
+				.AddInMemoryCollection(new Dictionary<string, string?> {
+					{"Webhooks:Sender:Retry:MaxRetries", "3"},
+					{"Webhooks:Sender:DefaultFormat", "Xml"}
+				})
+				.Build();
+
+			services.AddSingleton<IConfiguration>(configuration);
+
+			services.AddWebhookSender<Webhook>("Webhooks:Sender");
+
+			var provider = services.BuildServiceProvider();
+
+			var options = provider.GetRequiredService<IOptions<WebhookSenderOptions<Webhook>>>();
+
+			Assert.NotNull(options);
+
+			Assert.NotNull(provider.GetService<IWebhookSender<Webhook>>());
+			Assert.NotNull(provider.GetService<WebhookSender<Webhook>>());
+
+			Assert.Equal(3, options.Value.Retry.MaxRetries);
+			Assert.Equal(WebhookFormat.Xml, options.Value.DefaultFormat);
+		}
+
+		[Fact]
+		public static void AddSenderWithManualOptions() {
+			var services = new ServiceCollection();
+
+			services.AddWebhookSender<Webhook>(new WebhookSenderOptions<Webhook> {
+				Retry = {
+					MaxRetries = 32
+				},
+				DefaultFormat = WebhookFormat.Xml
+			});
+
+			var provider = services.BuildServiceProvider();
+
+			var options = provider.GetRequiredService<IOptions<WebhookSenderOptions<Webhook>>>();
+
+			Assert.NotNull(options);
+
+			Assert.NotNull(provider.GetService<IWebhookSender<Webhook>>());
+			Assert.NotNull(provider.GetService<WebhookSender<Webhook>>());
+
+			Assert.Equal(32, options.Value.Retry.MaxRetries);
+			Assert.Equal(WebhookFormat.Xml, options.Value.DefaultFormat);
+		}
+	}
+
+	class Webhook {
+	}
+}

--- a/test/Deveel.Webhooks.XUnit/Webhooks/TenantWebhookNotificationTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/TenantWebhookNotificationTests.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -46,18 +41,17 @@ namespace Deveel.Webhooks {
 			subscriptionResolver = Services.GetRequiredService<TestTenantSubscriptionResolver>();
 		}
 
-		protected override void ConfigureWebhookService(WebhookSubscriptionBuilder<TestWebhookSubscription> builder) {
-			builder
-				.UseSubscriptionManager()
-				.UseNotifier<Webhook>(config => config
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddWebhookNotifier<Webhook>(config => config
 					.UseTenantNotifier()
-					.UseWebhookFactory<DefaultWebhookFactory>()
 					.UseLinqFilter()
 					.UseTenantSubscriptionResolver<TestTenantSubscriptionResolver>(ServiceLifetime.Singleton)
 					.UseSender(options => {
 						options.Retry.MaxRetries = 2;
 						options.Retry.Timeout = TimeSpan.FromSeconds(TimeOutSeconds);
 					}));
+
+			base.ConfigureServices(services);
 		}
 
 		protected override async Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -42,17 +37,16 @@ namespace Deveel.Webhooks {
 			subscriptionResolver = Services.GetRequiredService<TestSubscriptionResolver>();
 		}
 
-		protected override void ConfigureWebhookService(WebhookSubscriptionBuilder<TestWebhookSubscription> builder) {
-			builder
-				.UseSubscriptionManager()
-				.UseNotifier<Webhook>(config => config
-					.UseWebhookFactory<DefaultWebhookFactory>()
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddWebhookNotifier<Webhook>(config => config
 					.UseLinqFilter()
 					.UseSubscriptionResolver<TestSubscriptionResolver>(ServiceLifetime.Singleton)
 					.UseSender(options => {
 						options.Retry.MaxRetries = 2;
 						options.Retry.Timeout = TimeSpan.FromSeconds(TimeOutSeconds);
 					}));
+
+			base.ConfigureServices(services);
 		}
 
 		protected override async Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookServiceTestBase.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookServiceTestBase.cs
@@ -33,11 +33,14 @@ namespace Deveel.Webhooks {
 		protected IServiceProvider Services { get; }
 
 		private IServiceProvider BuildServiceProvider(ITestOutputHelper outputHelper) {
-			return new ServiceCollection()
+			var services = new ServiceCollection()
 				.AddWebhookSubscriptions<TestWebhookSubscription>(buidler => ConfigureWebhookService(buidler))
 				.AddTestHttpClient(OnRequestAsync)
-				.AddLogging(logging => logging.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Trace))
-				.BuildServiceProvider();
+				.AddLogging(logging => logging.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Trace));
+
+			ConfigureServices(services);
+
+			return services.BuildServiceProvider();
 		}
 
 		protected virtual Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {


### PR DESCRIPTION
The `IWebhookSubscriptionResolver` is a service that is not necessarily bound to the Webhook Subscription Management package: future implementations might use a remote service to query them (eg. in a _microserviced_ architecture).

The changes contained in this Pull Request 

* Remove the logical registration of the IWebhookSubscriptionResolver from the WebhookSubscriptionBuilder object
* The `DefaultWebhookSubscriptionResolver` is registered by default when registering the _Webhook Notifier_ service (can be overridden with calls to `.UseSubscriptionResolver()` from the builder)