### PR TITLE
Batch Sending of Webhooks

### DIFF
--- a/samples/WebhookNotifierApp/Services/UserCreatedWebhookFactory.cs
+++ b/samples/WebhookNotifierApp/Services/UserCreatedWebhookFactory.cs
@@ -8,17 +8,19 @@ namespace Deveel.Webhooks.Services {
 			this.userResolver = userResolver;
 		}
 
-		public async Task<IdentityWebhook> CreateAsync(IWebhookSubscription subscription, EventInfo eventInfo, CancellationToken cancellationToken = default) {
-			var userCreated = (UserCreatedEvent?)eventInfo.Data;
+		public async Task<IdentityWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default) {
+			var @event = notification.SingleEvent;
+
+			var userCreated = (UserCreatedEvent?)@event.Data;
 			var user = await userResolver.ResolveUserAsync(userCreated!.UserId, cancellationToken);
 
 			if (user == null)
 				throw new InvalidOperationException();
 
 			return new IdentityWebhook {
-				EventId = eventInfo.Id,
+				EventId = @event.Id,
 				EventType = "user_created",
-				TimeStamp = eventInfo.TimeStamp,
+				TimeStamp = @event.TimeStamp,
 				User = user
 			};
 		}

--- a/samples/WebhookNotifierApp/Services/UserCreatedWebhookFactory.cs
+++ b/samples/WebhookNotifierApp/Services/UserCreatedWebhookFactory.cs
@@ -8,8 +8,8 @@ namespace Deveel.Webhooks.Services {
 			this.userResolver = userResolver;
 		}
 
-		public async Task<IdentityWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default) {
-			var @event = notification.SingleEvent;
+		public async Task<IList<IdentityWebhook>> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default) {
+			var @event = notification.Events[0];
 
 			var userCreated = (UserCreatedEvent?)@event.Data;
 			var user = await userResolver.ResolveUserAsync(userCreated!.UserId, cancellationToken);
@@ -17,11 +17,13 @@ namespace Deveel.Webhooks.Services {
 			if (user == null)
 				throw new InvalidOperationException();
 
-			return new IdentityWebhook {
-				EventId = @event.Id,
-				EventType = "user_created",
-				TimeStamp = @event.TimeStamp,
-				User = user
+			return new [] { 
+				new IdentityWebhook {
+					EventId = @event.Id,
+					EventType = @event.EventType,
+					TimeStamp = @event.TimeStamp,
+					User = user
+				} 
 			};
 		}
 	}

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/DefaultMongoWebhookConverter.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/DefaultMongoWebhookConverter.cs
@@ -32,9 +32,6 @@ namespace Deveel.Webhooks {
 		/// Converts the given <see cref="EventInfo"/> and the webhook object into
 		/// a <see cref="MongoWebhook"/> object.
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The event information that is being notified.
-		/// </param>
 		/// <param name="webhook">
 		/// The webhook that was notified to the subscribers.
 		/// </param>
@@ -42,7 +39,7 @@ namespace Deveel.Webhooks {
 		/// Returns an instance of <see cref="MongoWebhook"/> that represents the
 		/// webhook that can be stored into the database.
 		/// </returns>
-		public MongoWebhook ConvertWebhook(EventInfo eventInfo, TWebhook webhook) {
+		public MongoWebhook ConvertWebhook(EventNotification notification, TWebhook webhook) {
 			if (webhook is IWebhook obj) {
 				return new MongoWebhook {
 					WebhookId = obj.Id,
@@ -52,10 +49,14 @@ namespace Deveel.Webhooks {
 				};
 			}
 
+			// TODO: we should support multiple events in a single notification
+
+			var firstEvent = notification.Events.First();
+
 			return new MongoWebhook {
-				EventType = eventInfo.EventType,
-				TimeStamp = eventInfo.TimeStamp,
-				WebhookId = eventInfo.Id,
+				EventType = notification.EventType,
+				TimeStamp = firstEvent.TimeStamp,
+				WebhookId = notification.NotificationId,
 				Data = BsonValueUtil.ConvertData(webhook)
 			};
 		}

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/DefaultMongoWebhookConverter.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/DefaultMongoWebhookConverter.cs
@@ -32,6 +32,9 @@ namespace Deveel.Webhooks {
 		/// Converts the given <see cref="EventInfo"/> and the webhook object into
 		/// a <see cref="MongoWebhook"/> object.
 		/// </summary>
+		/// <param name="notification">
+		/// The event notification that was sent to the subscribers.
+		/// </param>
 		/// <param name="webhook">
 		/// The webhook that was notified to the subscribers.
 		/// </param>

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/IWebhookConverter.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/IWebhookConverter.cs
@@ -26,10 +26,6 @@ namespace Deveel.Webhooks {
         /// Converts the given webhook to an object that can be stored
         /// in a MongoDB database.
         /// </summary>
-		/// <param name="eventInfo">
-		/// The information about the event that triggered the
-		/// notification of the webhook.
-		/// </param>
         /// <param name="webhook">
         /// The instance of the webhook to be converted.
         /// </param>
@@ -37,6 +33,6 @@ namespace Deveel.Webhooks {
         /// Returns an instance of <see cref="MongoWebhook"/>
         /// that can be stored in a MongoDB database.
         /// </returns>
-        MongoWebhook ConvertWebhook(EventInfo eventInfo, TWebhook webhook);
+        MongoWebhook ConvertWebhook(EventNotification notification, TWebhook webhook);
     }
 }

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/IWebhookConverter.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/IWebhookConverter.cs
@@ -26,6 +26,9 @@ namespace Deveel.Webhooks {
         /// Converts the given webhook to an object that can be stored
         /// in a MongoDB database.
         /// </summary>
+		/// <param name="notification">
+		/// The event notification that was sent to the subscribers.
+		/// </param>
         /// <param name="webhook">
         /// The instance of the webhook to be converted.
         /// </param>

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookDeliveryResultLogger.cs
@@ -70,6 +70,9 @@ namespace Deveel.Webhooks {
 		/// Converts the given result to an object that can be stored in the
 		/// MongoDB database collection.
 		/// </summary>
+		/// <param name="notification">
+		/// The aggregate of the events that are being delivered to the receiver.
+		/// </param>
 		/// <param name="eventInfo">
 		/// The information about the event that triggered the delivery of the webhook.
 		/// </param>
@@ -157,6 +160,9 @@ namespace Deveel.Webhooks {
 		/// Converts the given webhook to an object that can be stored in the
 		/// MongoDB database collection.
 		/// </summary>
+		/// <param name="notification">
+		/// The aggregate of the events that are being delivered to the receiver.
+		/// </param>
 		/// <param name="webhook">
 		/// The instance of the webhook to convert.
 		/// </param>

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookDeliveryResultLogger.cs
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections;
-using System.Reflection;
-
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using MongoDB.Bson;
 
 namespace Deveel.Webhooks {
 	/// <summary>
@@ -87,14 +82,14 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns an object that can be stored in the MongoDB database collection.
 		/// </returns>
-		protected virtual TResult ConvertResult(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result) {
+		protected virtual TResult ConvertResult(EventNotification notification, EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result) {
 			var obj = new TResult();
 
 			obj.TenantId = subscription.TenantId;
 			obj.OperationId = result.OperationId;
 			obj.EventInfo = CreateEvent(eventInfo);
 			obj.Receiver = CreateReceiver(subscription);
-			obj.Webhook = ConvertWebhook(eventInfo, result.Webhook);
+			obj.Webhook = ConvertWebhook(notification, result.Webhook);
 			obj.DeliveryAttempts = result.Attempts?.Select(ConvertDeliveryAttempt).ToList() 
 				?? new List<MongoWebhookDeliveryAttempt>();
 
@@ -162,9 +157,6 @@ namespace Deveel.Webhooks {
 		/// Converts the given webhook to an object that can be stored in the
 		/// MongoDB database collection.
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The information about the event that triggered the delivery of the webhook.
-		/// </param>
 		/// <param name="webhook">
 		/// The instance of the webhook to convert.
 		/// </param>
@@ -175,15 +167,15 @@ namespace Deveel.Webhooks {
 		/// Thrown when the given type of webhook is not supported by this instance and
 		/// no converter was provided.
 		/// </exception>
-		protected virtual MongoWebhook ConvertWebhook(EventInfo eventInfo, TWebhook webhook) {
+		protected virtual MongoWebhook ConvertWebhook(EventNotification notification, TWebhook webhook) {
 			if (webhookConverter != null)
-				return webhookConverter.ConvertWebhook(eventInfo, webhook);
+				return webhookConverter.ConvertWebhook(notification, webhook);
 
 			throw new NotSupportedException("The given type of webhook is not supported by this instance of the logger");
 		}
 
 		/// <inheritdoc/>
-		public async Task LogResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
+		public async Task LogResultAsync(EventNotification notification, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
 			ArgumentNullException.ThrowIfNull(result, nameof(result));
 			ArgumentNullException.ThrowIfNull(subscription, nameof(subscription));
 
@@ -195,11 +187,11 @@ namespace Deveel.Webhooks {
 				typeof(TWebhook), subscription.TenantId);
 
 			try {
-				var resultObj = ConvertResult(eventInfo, subscription, result);
+				var results = notification.Select(e => ConvertResult(notification, e, subscription, result));
 
 				var repository = await RepositoryProvider.GetRepositoryAsync(subscription.TenantId, cancellationToken);
 
-				await repository.AddAsync(resultObj, cancellationToken);
+				await repository.AddRangeAsync(results, cancellationToken);
 			} catch (Exception ex) {
 				Logger.LogError(ex, "Could not log the result of the delivery of the Webhook of type '{WebhookType}' for tenant '{TenantId}' because of an error",
 					typeof(TWebhook), subscription.TenantId);

--- a/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
+++ b/src/Deveel.Webhooks.Service.MongoDb/Webhooks/MongoDbWebhookStorageBuilder.cs
@@ -202,7 +202,7 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns the current instance of the builder for chaining.
 		/// </returns>
-		public MongoDbWebhookStorageBuilder<TSubscription> UseWebhookConverter<TWebhook>(Func<EventInfo, TWebhook, MongoWebhook> converter)
+		public MongoDbWebhookStorageBuilder<TSubscription> UseWebhookConverter<TWebhook>(Func<EventNotification, TWebhook, MongoWebhook> converter)
 			where TWebhook : class {
 
 			Services.AddSingleton<IMongoWebhookConverter<TWebhook>>(new MongoWebhookConverterWrapper<TWebhook>(converter));
@@ -211,13 +211,14 @@ namespace Deveel.Webhooks {
 		}
 
 		private class MongoWebhookConverterWrapper<TWebhook> : IMongoWebhookConverter<TWebhook> where TWebhook : class {
-			private readonly Func<EventInfo, TWebhook, MongoWebhook> converter;
+			private readonly Func<EventNotification, TWebhook, MongoWebhook> converter;
 
-			public MongoWebhookConverterWrapper(Func<EventInfo, TWebhook, MongoWebhook> converter) {
+			public MongoWebhookConverterWrapper(Func<EventNotification, TWebhook, MongoWebhook> converter) {
 				this.converter = converter;
 			}
 
-			public MongoWebhook ConvertWebhook(EventInfo eventInfo, TWebhook webhook) => converter.Invoke(eventInfo, webhook);
+			public MongoWebhook ConvertWebhook(EventNotification notification, TWebhook webhook) 
+				=> converter.Invoke(notification, webhook);
 		}
 	}
 }

--- a/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionResolver.cs
+++ b/src/Deveel.Webhooks.Service/Webhooks/WebhookSubscriptionResolver.cs
@@ -76,7 +76,7 @@ namespace Deveel.Webhooks {
 				var list = await GetCachedAsync(eventType, cancellationToken);
 
 				if (list == null) {
-					logger.LogTrace("No webhook subscriptions to event {EventType} of tenant {TenantId} were found in cache", eventType);
+					logger.LogTrace("No webhook subscriptions to event {EventType} were found in cache", eventType);
 
 					var result = await repository.GetByEventTypeAsync(eventType, activeOnly, cancellationToken);
 					list = result.Cast<IWebhookSubscription>().ToList();

--- a/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory.cs
+++ b/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Microsoft.Extensions.Options;
+
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// A default implementation of the <see cref="IWebhookFactory{TWebhook}"/>
@@ -19,5 +21,7 @@ namespace Deveel.Webhooks {
 	/// provided by the subscription and the event.
 	/// </summary>
 	public sealed class DefaultWebhookFactory : DefaultWebhookFactory<Webhook> {
+		public DefaultWebhookFactory(IOptions<WebhookFactoryOptions<Webhook>> options) : base(options) {
+		}
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
+++ b/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
@@ -44,8 +44,8 @@ namespace Deveel.Webhooks {
 		/// webhooks from a notification for a subscription.
 		/// </summary>
 		/// <param name="options"></param>
-		public DefaultWebhookFactory(IOptions<WebhookFactoryOptions<TWebhook>> options) {
-			Options = options.Value;
+		public DefaultWebhookFactory(IOptions<WebhookFactoryOptions<TWebhook>>? options = null) {
+			Options = options?.Value ?? new WebhookFactoryOptions<TWebhook>();
 		}
 
 		protected WebhookFactoryOptions<TWebhook> Options { get; }

--- a/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
+++ b/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// A default implementation of the <see cref="IWebhookFactory{TWebhook}"/>
@@ -29,7 +26,7 @@ namespace Deveel.Webhooks {
 	/// </para>
 	/// <para>
 	/// It is possible to create a custom webhook type by implementing
-	/// this factory and overriding the <see cref="CreateData(IWebhookSubscription, EventInfo)"/>
+	/// this factory and overriding the <see cref="CreateData(IWebhookSubscription, EventNotification)"/>
 	/// </para>
 	/// <para>
 	/// By default the <see cref="Webhook"/> class is configured with attributes from
@@ -47,14 +44,38 @@ namespace Deveel.Webhooks {
 		/// <param name="subscription">
 		/// The subscription that is listening to the event
 		/// </param>
-		/// <param name="eventInfo">
-		/// The event that is being delivered to the subscription
+		/// <param name="notification">
+		/// The aggregate of the events that are being delivered to the subscription.
 		/// </param>
+		/// <remarks>
+		/// The default implementation of this method returns an array of
+		/// objects, each one created by the <see cref="CreateEventData(IWebhookSubscription, EventInfo)"/>,
+		/// when the notification contains multiple events, or the single object
+		/// if the notification contains a single event.
+		/// </remarks>
 		/// <returns>
 		/// Returns a data object that is carried by the webhook
 		/// through the <see cref="Webhook.Data"/> property.
 		/// </returns>
-		protected virtual object? CreateData(IWebhookSubscription subscription, EventInfo eventInfo) {
+		protected virtual object? CreateData(IWebhookSubscription subscription, EventNotification notification) {
+			if (notification.HasSingleEvent)
+				return CreateEventData(subscription, notification.SingleEvent);
+
+			return notification.Events.Select(x => CreateEventData(subscription, x)).ToArray();
+		}
+
+		/// <summary>
+		/// When overridden, creates the data object that is carried by
+		/// a webhook to the receiver.
+		/// </summary>
+		/// <param name="subscription"></param>
+		/// <param name="eventInfo"></param>
+		/// <remarks>
+		/// The default implementation of this method returns the <see cref="EventInfo.Data"/>
+		/// object of the given event.
+		/// </remarks>
+		/// <returns></returns>
+		protected virtual object? CreateEventData(IWebhookSubscription subscription, EventInfo eventInfo) {
 			return eventInfo.Data;
 		}
 
@@ -74,19 +95,14 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that resolves to the created webhook
 		/// </returns>
-		public Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken) {
-			if (!notification.HasSingleEvent)
-				throw new WebhookException("Multiple events per notification not supported yet.");
-			
-			var @event = notification.SingleEvent;
-
+		public virtual Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken) {
 			var webhook = new TWebhook {
-				Id = @event.Id,
-				EventType = @event.EventType,
+				Id = notification.NotificationId,
+				EventType = notification.EventType,
 				SubscriptionId = subscription.SubscriptionId,
 				Name = subscription.Name,
-				TimeStamp = @event.TimeStamp,
-				Data = @event.Data,
+				TimeStamp = notification.TimeStamp,
+				Data = CreateData(subscription, notification),
 			};
 
 			return Task.FromResult(webhook);

--- a/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
+++ b/src/Deveel.Webhooks/Webhooks/DefaultWebhookFactory_1.cs
@@ -65,7 +65,7 @@ namespace Deveel.Webhooks {
 		/// <param name="subscription">
 		/// The subscription that is listening to the event
 		/// </param>
-		/// <param name="eventInfo">
+		/// <param name="notification">
 		/// The event that is being delivered to the subscription
 		/// </param>
 		/// <param name="cancellationToken">
@@ -74,14 +74,19 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that resolves to the created webhook
 		/// </returns>
-		public Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventInfo eventInfo, CancellationToken cancellationToken) {
+		public Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken) {
+			if (!notification.HasSingleEvent)
+				throw new WebhookException("Multiple events per notification not supported yet.");
+			
+			var @event = notification.SingleEvent;
+
 			var webhook = new TWebhook {
-				Id = eventInfo.Id,
-				EventType = eventInfo.EventType,
+				Id = @event.Id,
+				EventType = @event.EventType,
 				SubscriptionId = subscription.SubscriptionId,
 				Name = subscription.Name,
-				TimeStamp = eventInfo.TimeStamp,
-				Data = eventInfo.Data,
+				TimeStamp = @event.TimeStamp,
+				Data = @event.Data,
 			};
 
 			return Task.FromResult(webhook);

--- a/src/Deveel.Webhooks/Webhooks/EventNotification.cs
+++ b/src/Deveel.Webhooks/Webhooks/EventNotification.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Deveel.Webhooks {
+	public sealed class EventNotification : IEnumerable<EventInfo> {
+		public EventNotification(string eventType, IEnumerable<EventInfo> events) {
+			ArgumentNullException.ThrowIfNull(events, nameof(events));
+
+#if NET7_0_OR_GREATER
+			ArgumentException.ThrowIfNullOrEmpty(eventType, nameof(eventType));
+#else
+			if (String.IsNullOrEmpty(eventType))
+				throw new ArgumentException("The event type cannot be null or empty", nameof(eventType));
+#endif
+			if (!events.Any())
+				throw new ArgumentException("The list of events cannot be empty", nameof(events));
+
+			ValidateAllEventsOfType(eventType, events);
+
+			Events = events.ToList().AsReadOnly();
+			EventType = eventType;
+			NotificationId = Guid.NewGuid().ToString();
+		}
+
+		public EventNotification(EventInfo eventInfo)
+			: this(eventInfo.EventType, new[] {eventInfo}) {
+		}
+
+		public IReadOnlyList<EventInfo> Events { get; }
+
+		public bool HasSingleEvent => Events.Count == 1;
+
+		public EventInfo SingleEvent {
+			get {
+				if (!HasSingleEvent)
+					throw new InvalidOperationException("The notification has more than one event");
+
+				return Events[0];
+			}
+		}
+
+		public string EventType { get; }
+
+		public string NotificationId { get; set; }
+
+		public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
+
+		public IEnumerator<EventInfo> GetEnumerator() => Events.GetEnumerator();
+
+		[ExcludeFromCodeCoverage]
+		IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Events).GetEnumerator();
+
+		private static void ValidateAllEventsOfType(string eventType, IEnumerable<EventInfo> events) {
+			foreach (var @event in events) {
+				if (!String.Equals(@event.EventType, eventType, StringComparison.OrdinalIgnoreCase))
+					throw new ArgumentException($"The event {@event.EventType} is not of the type {eventType}");
+			}
+		}
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/EventNotification.cs
+++ b/src/Deveel.Webhooks/Webhooks/EventNotification.cs
@@ -1,8 +1,39 @@
-﻿using System.Collections;
+﻿// Copyright 2022-2024 Antonello Provenzano
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Deveel.Webhooks {
+	/// <summary>
+	/// Represents a notification of one or more events of the same type,
+	/// to be delivered to a receiver.
+	/// </summary>
 	public sealed class EventNotification : IEnumerable<EventInfo> {
+		/// <summary>
+		/// Constructs the notification with the given type and events.
+		/// </summary>
+		/// <param name="eventType">
+		/// The type of the events that are being notified.
+		/// </param>
+		/// <param name="events">
+		/// The list of events that are being notified.
+		/// </param>
+		/// <exception cref="ArgumentException">
+		/// Thrown when the given event type is null or empty, or when the list
+		/// is empty, or when the list contains events that are not of the given type.
+		/// </exception>
 		public EventNotification(string eventType, IEnumerable<EventInfo> events) {
 			ArgumentNullException.ThrowIfNull(events, nameof(events));
 
@@ -20,16 +51,42 @@ namespace Deveel.Webhooks {
 			Events = events.ToList().AsReadOnly();
 			EventType = eventType;
 			NotificationId = Guid.NewGuid().ToString();
+			TimeStamp = DateTimeOffset.UtcNow;
 		}
 
+		/// <summary>
+		/// Constructs the notification of a single event.
+		/// </summary>
+		/// <param name="eventInfo">
+		/// The event that is being notified.
+		/// </param>
 		public EventNotification(EventInfo eventInfo)
 			: this(eventInfo.EventType, new[] {eventInfo}) {
+			NotificationId = eventInfo.Id;
+			TimeStamp = eventInfo.TimeStamp;
 		}
 
+		/// <summary>
+		/// Gets the list of events that are being notified.
+		/// </summary>
 		public IReadOnlyList<EventInfo> Events { get; }
 
+		/// <summary>
+		/// Gets a value indicating if the notification has a single event.
+		/// </summary>
 		public bool HasSingleEvent => Events.Count == 1;
 
+		/// <summary>
+		/// Gets the single event of the notification.
+		/// </summary>
+		/// <remarks>
+		/// It is recommended to use this property only after checking that
+		/// the notification has a single event, using the <see cref="HasSingleEvent"/>.
+		/// </remarks>
+		/// <exception cref="InvalidOperationException">
+		/// Thrown when the notification has more than one event.
+		/// </exception>
+		/// <seealso cref="HasSingleEvent"/>
 		public EventInfo SingleEvent {
 			get {
 				if (!HasSingleEvent)
@@ -39,12 +96,27 @@ namespace Deveel.Webhooks {
 			}
 		}
 
+		/// <summary>
+		/// Gets the type of the events that are being notified.
+		/// </summary>
 		public string EventType { get; }
 
+		/// <summary>
+		/// Gets or sets the unique identifier of the notification.
+		/// </summary>
 		public string NotificationId { get; set; }
 
+		/// <summary>
+		/// Gets or sets the timestamp of the notification.
+		/// </summary>
+		public DateTimeOffset TimeStamp { get; set; }
+
+		/// <summary>
+		/// Gets or sets the properties of the notification.
+		/// </summary>
 		public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
 
+		/// <inheritdoc/>
 		public IEnumerator<EventInfo> GetEnumerator() => Events.GetEnumerator();
 
 		[ExcludeFromCodeCoverage]
@@ -55,6 +127,32 @@ namespace Deveel.Webhooks {
 				if (!String.Equals(@event.EventType, eventType, StringComparison.OrdinalIgnoreCase))
 					throw new ArgumentException($"The event {@event.EventType} is not of the type {eventType}");
 			}
+		}
+
+		/// <summary>
+		/// Implicitly converts an event into a notification.
+		/// </summary>
+		/// <param name="eventInfo">
+		/// The event to be notified.
+		/// </param>
+		public static implicit operator EventNotification(EventInfo eventInfo) {
+			return new EventNotification(eventInfo);
+		}
+
+		/// <summary>
+		/// Implicitly converts a list of events into a notification.
+		/// </summary>
+		/// <param name="events">
+		/// The list of events to be notified.
+		/// </param>
+		/// <exception cref="ArgumentException">
+		/// Thrown if the list of events is empty.
+		/// </exception>
+		public static implicit operator EventNotification(EventInfo[] events) {
+			if (events.Length == 0)
+				throw new ArgumentException("The list of events cannot be empty", nameof(events));
+
+			return new EventNotification(events[0].EventType, events);
 		}
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/EventNotification.cs
+++ b/src/Deveel.Webhooks/Webhooks/EventNotification.cs
@@ -72,31 +72,6 @@ namespace Deveel.Webhooks {
 		public IReadOnlyList<EventInfo> Events { get; }
 
 		/// <summary>
-		/// Gets a value indicating if the notification has a single event.
-		/// </summary>
-		public bool HasSingleEvent => Events.Count == 1;
-
-		/// <summary>
-		/// Gets the single event of the notification.
-		/// </summary>
-		/// <remarks>
-		/// It is recommended to use this property only after checking that
-		/// the notification has a single event, using the <see cref="HasSingleEvent"/>.
-		/// </remarks>
-		/// <exception cref="InvalidOperationException">
-		/// Thrown when the notification has more than one event.
-		/// </exception>
-		/// <seealso cref="HasSingleEvent"/>
-		public EventInfo SingleEvent {
-			get {
-				if (!HasSingleEvent)
-					throw new InvalidOperationException("The notification has more than one event");
-
-				return Events[0];
-			}
-		}
-
-		/// <summary>
 		/// Gets the type of the events that are being notified.
 		/// </summary>
 		public string EventType { get; }

--- a/src/Deveel.Webhooks/Webhooks/ITenantWebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/ITenantWebhookNotifier.cs
@@ -36,12 +36,14 @@ namespace Deveel.Webhooks {
 		/// </summary>
 		/// <param name="tenantId">The scope of the tenant holding the subscriptions
 		/// to the given event.</param>
-		/// <param name="eventInfo">The ifnormation of the event that occurred.</param>
+		/// <param name="notification">
+		/// The aggregate of the events to be notified to the subscribers.
+		/// </param>
 		/// <param name="cancellationToken"></param>
 		/// <returns>
 		/// Returns an object that describes the aggregated final result of 
 		/// the notification process executed.
 		/// </returns>
-		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(string tenantId, EventInfo eventInfo, CancellationToken cancellationToken);
+		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(string tenantId, EventNotification notification, CancellationToken cancellationToken);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/IWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookDeliveryResultLogger.cs
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// Defines a service that is able to log the result of 
@@ -28,8 +24,8 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Logs the result of a delivery of a webhook
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The information about the event that triggered the notification.
+		/// <param name="notification">
+		/// 
 		/// </param>
 		/// <param name="subscription">
 		/// The subscription that was used to deliver the webhook
@@ -43,6 +39,6 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that when completed will log the result of the delivery
 		/// </returns>
-		Task LogResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken = default);
+		Task LogResultAsync(EventNotification notification, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
@@ -31,9 +31,6 @@ namespace Deveel.Webhooks {
 		/// <param name="subscription">
 		/// The subscription that is requesting the webhook.
 		/// </param>
-		/// <param name="eventInfo">
-		/// The event information that is triggering the delivery of the webhook.
-		/// </param>
 		/// <param name="cancellationToken">
 		/// A token that can be used to cancel the operation.
 		/// </param>
@@ -41,6 +38,6 @@ namespace Deveel.Webhooks {
 		/// Returns an instance of the webhook that will be delivered to
 		/// the receiver that is subscribed to the event.
 		/// </returns>
-		Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventInfo eventInfo, CancellationToken cancellationToken = default);
+		Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
@@ -19,7 +19,7 @@ using System.Threading.Tasks;
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// Defines a factory that can create <typeparamref name="TWebhook"/> 
-	/// instances given the subscription and the event information.
+	/// instances given the subscription and the events notification.
 	/// </summary>
 	/// <typeparam name="TWebhook">
 	/// The type of the webhook instance to create.
@@ -30,6 +30,9 @@ namespace Deveel.Webhooks {
 		/// </summary>
 		/// <param name="subscription">
 		/// The subscription that is requesting the webhook.
+		/// </param>
+		/// <param name="notification">
+		/// The notification that is being delivered to the receiver.
 		/// </param>
 		/// <param name="cancellationToken">
 		/// A token that can be used to cancel the operation.

--- a/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookFactory.cs
@@ -41,6 +41,6 @@ namespace Deveel.Webhooks {
 		/// Returns an instance of the webhook that will be delivered to
 		/// the receiver that is subscribed to the event.
 		/// </returns>
-		Task<TWebhook> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default);
+		Task<IList<TWebhook>> CreateAsync(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/IWebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/IWebhookNotifier.cs
@@ -36,7 +36,9 @@ namespace Deveel.Webhooks {
 		/// Notifies to the subscribers the occurrence of the
 		/// given event.
 		/// </summary>
-		/// <param name="eventInfo">The ifnormation of the event that occurred.</param>
+		/// <param name="notification">
+		/// The aggregate of the events to be notified to the subscribers.
+		/// </param>
 		/// <param name="cancellationToken">
 		/// A token that can be used to cancel the notification process.
 		/// </param>
@@ -44,6 +46,6 @@ namespace Deveel.Webhooks {
 		/// Returns an object that describes the aggregated final result of 
 		/// the notification process executed.
 		/// </returns>
-		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventInfo eventInfo, CancellationToken cancellationToken = default);
+		Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventNotification notification, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/NullWebhookDeliveryResultLogger.cs
+++ b/src/Deveel.Webhooks/Webhooks/NullWebhookDeliveryResultLogger.cs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Deveel.Webhooks {
 	/// <summary>
 	/// A default implementation of <see cref="IWebhookDeliveryResultLogger{TWebhook}"/> that
@@ -34,7 +31,7 @@ namespace Deveel.Webhooks {
 		public static readonly NullWebhookDeliveryResultLogger<TWebhook> Instance = new NullWebhookDeliveryResultLogger<TWebhook>();
 
 		/// <inheritdoc/>
-		public Task LogResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
+		public Task LogResultAsync(EventNotification notification, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> result, CancellationToken cancellationToken) {
 			return Task.CompletedTask;
 		}
 	}

--- a/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifier.cs
@@ -74,8 +74,8 @@ namespace Deveel.Webhooks {
 		/// <param name="tenantId">
 		/// The identifier of the tenant for which the event was raised.
 		/// </param>
-		/// <param name="eventInfo">
-		/// The information about the event that was raised.
+		/// <param name="notification">
+		/// The aggreate of the events to notify.
 		/// </param>
 		/// <param name="cancellationToken">
 		/// A cancellation token that can be used to cancel the operation.
@@ -83,12 +83,12 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a list of subscriptions that should be notified for the given event.
 		/// </returns>
-		protected virtual async Task<IList<IWebhookSubscription>> ResolveSubscriptionsAsync(string tenantId, EventInfo eventInfo, CancellationToken cancellationToken) {
+		protected virtual async Task<IList<IWebhookSubscription>> ResolveSubscriptionsAsync(string tenantId, EventNotification notification, CancellationToken cancellationToken) {
 			if (subscriptionResolver == null)
 				return new List<IWebhookSubscription>();
 
 			try {
-				return await subscriptionResolver.ResolveSubscriptionsAsync(tenantId, eventInfo.EventType, true, cancellationToken);
+				return await subscriptionResolver.ResolveSubscriptionsAsync(tenantId, notification.EventType, true, cancellationToken);
 			} catch(WebhookException) {
 				throw;
 			} catch (Exception ex) {
@@ -97,18 +97,18 @@ namespace Deveel.Webhooks {
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<WebhookNotificationResult<TWebhook>> NotifyAsync(string tenantId, EventInfo eventInfo, CancellationToken cancellationToken) {
+		public virtual async Task<WebhookNotificationResult<TWebhook>> NotifyAsync(string tenantId, EventNotification notification, CancellationToken cancellationToken) {
 			IEnumerable<IWebhookSubscription> subscriptions;
 
 			try {
-				subscriptions = await ResolveSubscriptionsAsync(tenantId, eventInfo, cancellationToken);
+				subscriptions = await ResolveSubscriptionsAsync(tenantId, notification, cancellationToken);
 			} catch (WebhookException ex) {
 				Logger.LogError(ex, "Error while resolving the subscriptions to event {EventType} for tenant '{TenantId}'", 
-					eventInfo.EventType, tenantId);
+					notification.EventType, tenantId);
 				throw;
 			}
 
-			return await NotifySubscriptionsAsync(eventInfo, subscriptions, cancellationToken);
+			return await NotifySubscriptionsAsync(notification, subscriptions, cancellationToken);
 		}
 	}
 }

--- a/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifierExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifierExtensions.cs
@@ -1,11 +1,45 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright 2022-2024 Antonello Provenzano
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Deveel.Webhooks {
+	/// <summary>
+	/// Extends the <see cref="ITenantWebhookNotifier{TWebhook}"/> with
+	/// methods to notify a tenant of a single event.
+	/// </summary>
 	public static class TenantWebhookNotifierExtensions {
+		/// <summary>
+		/// Notifies the tenant of the given event.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook to be notified.
+		/// </typeparam>
+		/// <param name="notifier">
+		/// The instance of the notifier to use to send the notification.
+		/// </param>
+		/// <param name="tenantId">
+		/// The unique identifier of the tenant to notify.
+		/// </param>
+		/// <param name="eventInfo">
+		/// The event that is being notified.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A cancellation token that can be used to cancel the notification.
+		/// </param>
+		/// <returns>
+		/// Returns the result of the notification process, that contains
+		/// the notification of a single event.
+		/// </returns>
 		public static Task<WebhookNotificationResult<TWebhook>> NotifyAsync<TWebhook>(this ITenantWebhookNotifier<TWebhook> notifier, string tenantId, EventInfo eventInfo, CancellationToken cancellationToken = default)
 			where TWebhook : class {
 			return notifier.NotifyAsync(tenantId, new EventNotification(eventInfo), cancellationToken);

--- a/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifierExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/TenantWebhookNotifierExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Deveel.Webhooks {
+	public static class TenantWebhookNotifierExtensions {
+		public static Task<WebhookNotificationResult<TWebhook>> NotifyAsync<TWebhook>(this ITenantWebhookNotifier<TWebhook> notifier, string tenantId, EventInfo eventInfo, CancellationToken cancellationToken = default)
+			where TWebhook : class {
+			return notifier.NotifyAsync(tenantId, new EventNotification(eventInfo), cancellationToken);
+		}
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/WebhookCreateStrategy.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookCreateStrategy.cs
@@ -1,0 +1,19 @@
+﻿namespace Deveel.Webhooks {
+	/// <summary>
+	/// The strategy to use when creating a webhook instance
+	/// from a notification.
+	/// </summary>
+	public enum WebhookCreateStrategy {
+		/// <summary>
+		/// The factory will create a single webhook instance
+		/// for each event in the notification.
+		/// </summary>
+		OnePerEvent = 1,
+
+		/// <summary>
+		/// The factory will create a single webhook instance
+		/// for all the events in the notification.
+		/// </summary>
+		OnePerNotification = 2
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/WebhookFactoryOptions.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookFactoryOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Deveel.Webhooks {
+	/// <summary>
+	/// Configures the behavior of the <see cref="DefaultWebhookFactory{TWebhook}"/>
+	/// when creating webhooks from a notification for a subscription.
+	/// </summary>
+	/// <typeparam name="TWebhook"></typeparam>
+	public class WebhookFactoryOptions<TWebhook> {
+		/// <summary>
+		/// Gets or sets the strategy to use when creating webhooks
+		/// from a notification for a subscription.
+		/// </summary>
+		public WebhookCreateStrategy CreateStrategy { get; set; } = WebhookCreateStrategy.OnePerNotification;
+	}
+}

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotificationResult.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotificationResult.cs
@@ -30,21 +30,23 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Constructs a notification result for the given event.
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The information of the event that was notified through webhooks.
+		/// <param name="notification">
+		/// The aggregate of the events to be notified to the subscribers.
 		/// </param>
 		/// <exception cref="ArgumentNullException">
-		/// Thrown when the given <paramref name="eventInfo"/> is <c>null</c>.
+		/// Thrown when the given <paramref name="notification"/> is <c>null</c>.
 		/// </exception>
-		public WebhookNotificationResult(EventInfo eventInfo) {
+		public WebhookNotificationResult(EventNotification notification) {
+			ArgumentNullException.ThrowIfNull(notification, nameof(notification));
+
 			deliveryResults = new ConcurrentDictionary<string, IList<WebhookDeliveryResult<TWebhook>>>();
-			EventInfo = eventInfo;
+			Notification = notification;
 		}
 
 		/// <summary>
 		/// Gets the information of the event that was notified.
 		/// </summary>
-		public EventInfo EventInfo { get; }
+		public EventNotification Notification { get; }
 
 		/// <summary>
 		/// Adds a delivery result for the given subscription.

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifier.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifier.cs
@@ -63,12 +63,12 @@ namespace Deveel.Webhooks {
 		}
 
 		/// <inheritdoc/>
-		protected virtual async Task<IEnumerable<IWebhookSubscription>> ResolveSubscriptionsAsync(EventInfo eventInfo, CancellationToken cancellationToken) {
+		protected virtual async Task<IEnumerable<IWebhookSubscription>> ResolveSubscriptionsAsync(EventNotification notification, CancellationToken cancellationToken) {
 			if (subscriptionResolver == null)
 				return new List<IWebhookSubscription>();
 
 			try {
-				return await subscriptionResolver.ResolveSubscriptionsAsync(eventInfo.EventType, true, cancellationToken);
+				return await subscriptionResolver.ResolveSubscriptionsAsync(notification.EventType, true, cancellationToken);
 			} catch (WebhookException) {
 				throw;
 			} catch (Exception ex) {
@@ -78,10 +78,10 @@ namespace Deveel.Webhooks {
 		}
 
 		/// <inheritdoc/>
-		public async Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventInfo eventInfo, CancellationToken cancellationToken) {
-			var subscriptions = await ResolveSubscriptionsAsync(eventInfo, cancellationToken);
+		public async Task<WebhookNotificationResult<TWebhook>> NotifyAsync(EventNotification notification, CancellationToken cancellationToken) {
+			var subscriptions = await ResolveSubscriptionsAsync(notification, cancellationToken);
 
-			return await NotifySubscriptionsAsync(eventInfo, subscriptions, cancellationToken);
+			return await NotifySubscriptionsAsync(notification, subscriptions, cancellationToken);
 
 		}
 	}

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierBase.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierBase.cs
@@ -200,23 +200,23 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that completes when the operation is done.
 		/// </returns>
-		protected virtual async Task LogDeliveryResultAsync(EventInfo eventInfo, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> deliveryResult, CancellationToken cancellationToken) {
+		protected virtual async Task LogDeliveryResultAsync(EventNotification notification, IWebhookSubscription subscription, WebhookDeliveryResult<TWebhook> deliveryResult, CancellationToken cancellationToken) {
 			try {
 				if (deliveryResultLogger != null)
-					await deliveryResultLogger.LogResultAsync(eventInfo, subscription, deliveryResult, cancellationToken);
+					await deliveryResultLogger.LogResultAsync(notification, subscription, deliveryResult, cancellationToken);
 			} catch (Exception ex) {
 				// If an error occurs here, we report it, but we don't throw it...
-				Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId!, eventInfo.EventType);
+				Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId!, notification.EventType);
 			}
 		}
 
-		private void TraceDeliveryResult(EventInfo eventInfo, WebhookDeliveryResult<TWebhook> deliveryResult) {
+		private void TraceDeliveryResult(EventNotification notification, WebhookDeliveryResult<TWebhook> deliveryResult) {
 			if (!deliveryResult.HasAttempted) {
-				Logger.WarnDeliveryNotAttempted(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), eventInfo.EventType);
+				Logger.WarnDeliveryNotAttempted(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), notification.EventType);
 			} else if (deliveryResult.Successful) {
-				Logger.TraceDeliveryDoneAfterAttempts(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), eventInfo.EventType, deliveryResult.Attempts.Count);
+				Logger.TraceDeliveryDoneAfterAttempts(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), notification.EventType, deliveryResult.Attempts.Count);
 			} else {
-				Logger.WarnDeliveryFailed(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), eventInfo.EventType, deliveryResult.Attempts.Count);
+				Logger.WarnDeliveryFailed(deliveryResult.Destination.Url.GetLeftPart(UriPartial.Path), notification.EventType, deliveryResult.Attempts.Count);
 			}
 
 			if (deliveryResult.HasAttempted) {
@@ -230,16 +230,16 @@ namespace Deveel.Webhooks {
 			}
 		}
 
-		private async Task NotifySubscription(WebhookNotificationResult<TWebhook> result, EventInfo eventInfo, IWebhookSubscription subscription, CancellationToken cancellationToken) {
+		private async Task NotifySubscription(WebhookNotificationResult<TWebhook> result, EventNotification notification, IWebhookSubscription subscription, CancellationToken cancellationToken) {
 			if (String.IsNullOrWhiteSpace(subscription.SubscriptionId))
 				throw new WebhookException("The subscription identifier is missing");
 
-			Logger.TraceEvaluatingSubscription(subscription.SubscriptionId, eventInfo.EventType);
+			Logger.TraceEvaluatingSubscription(subscription.SubscriptionId, notification.EventType);
 
-			var webhook = await CreateWebhook(subscription, eventInfo, cancellationToken);
+			var webhook = await CreateWebhook(subscription, notification, cancellationToken);
 
 			if (webhook == null) {
-				Logger.WarnWebhookNotCreated(subscription.SubscriptionId, eventInfo.EventType);				
+				Logger.WarnWebhookNotCreated(subscription.SubscriptionId, notification.EventType);				
 				return;
 			}
 
@@ -247,26 +247,26 @@ namespace Deveel.Webhooks {
 				var filter = BuildSubscriptionFilter(subscription);
 
 				if (await MatchesAsync(filter, webhook, cancellationToken)) {
-					Logger.TraceSubscriptionMatched(subscription.SubscriptionId, eventInfo.EventType);
+					Logger.TraceSubscriptionMatched(subscription.SubscriptionId, notification.EventType);
 
 					var deliveryResult = await SendAsync(subscription, webhook, cancellationToken);
 
 					result.AddDelivery(subscription.SubscriptionId, deliveryResult);
 
-					await LogDeliveryResultAsync(eventInfo, subscription, deliveryResult, cancellationToken);
+					await LogDeliveryResultAsync(notification, subscription, deliveryResult, cancellationToken);
 
-					TraceDeliveryResult(eventInfo, deliveryResult);
+					TraceDeliveryResult(notification, deliveryResult);
 
 					try {
 						await OnDeliveryResultAsync(subscription, webhook, deliveryResult, cancellationToken);
 					} catch (Exception ex) {
-						Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId, eventInfo.EventType);
+						Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId, notification.EventType);
 					}
 				} else {
-					Logger.TraceSubscriptionNotMatched(subscription.SubscriptionId, eventInfo.EventType);
+					Logger.TraceSubscriptionNotMatched(subscription.SubscriptionId, notification.EventType);
 				}
 			} catch (Exception ex) {
-				Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId, eventInfo.EventType);
+				Logger.LogUnknownEventDeliveryError(ex, subscription.SubscriptionId, notification.EventType);
 
 				await OnDeliveryErrorAsync(subscription, webhook, ex, cancellationToken);
 
@@ -278,8 +278,8 @@ namespace Deveel.Webhooks {
 		/// Performs the notification of the given event to the subscriptions
 		/// resolved that are listening for it.
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The information about the event that is being notified.
+		/// <param name="notification">
+		/// The aggregate of the events to be notified to the subscribers.
 		/// </param>
 		/// <param name="subscriptions">
 		/// The subscriptions that are listening for the event.
@@ -290,8 +290,8 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns a task that completes when the operation is done.
 		/// </returns>
-		protected virtual async Task<WebhookNotificationResult<TWebhook>> NotifySubscriptionsAsync(EventInfo eventInfo, IEnumerable<IWebhookSubscription> subscriptions, CancellationToken cancellationToken) {
-			var result = new WebhookNotificationResult<TWebhook>(eventInfo);
+		protected virtual async Task<WebhookNotificationResult<TWebhook>> NotifySubscriptionsAsync(EventNotification notification, IEnumerable<IWebhookSubscription> subscriptions, CancellationToken cancellationToken) {
+			var result = new WebhookNotificationResult<TWebhook>(notification);
 
 			// TODO: Make the parallel thread count configurable
 			var options = new ParallelOptions { 
@@ -300,7 +300,7 @@ namespace Deveel.Webhooks {
 			};
 
 			await Parallel.ForEachAsync(subscriptions, options, async (subscription, token) => {
-				await NotifySubscription(result, eventInfo, subscription, cancellationToken);
+				await NotifySubscription(result, notification, subscription, cancellationToken);
 			});
 
 
@@ -378,8 +378,8 @@ namespace Deveel.Webhooks {
 		/// <param name="subscription">
 		/// The subscription that is being notified.
 		/// </param>
-		/// <param name="eventInfo">
-		/// The information about the event that is being notified.
+		/// <param name="notification">
+		/// The aggregate of the events to be notified to the subscribers.
 		/// </param>
 		/// <param name="cancellationToken">
 		/// A cancellation token that can be used to cancel the operation.
@@ -389,11 +389,11 @@ namespace Deveel.Webhooks {
 		/// or <c>null</c> if it was not possible to constuct the data.
 		/// </returns>
 		/// <exception cref="WebhookException"></exception>
-		protected virtual async Task<TWebhook?> CreateWebhook(IWebhookSubscription subscription, EventInfo eventInfo, CancellationToken cancellationToken) {
+		protected virtual async Task<TWebhook?> CreateWebhook(IWebhookSubscription subscription, EventNotification notification, CancellationToken cancellationToken) {
 			try {
-				return await webhookFactory.CreateAsync(subscription, eventInfo, cancellationToken);
+				return await webhookFactory.CreateAsync(subscription, notification, cancellationToken);
 			} catch (Exception ex) {
-				Logger.LogWebhookCreationError(ex, subscription.SubscriptionId!, eventInfo.EventType);
+				Logger.LogWebhookCreationError(ex, subscription.SubscriptionId!, notification.EventType);
 				throw new WebhookException("An error occurred while creating a new webhook", ex);
 			}
 

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierBase.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierBase.cs
@@ -185,8 +185,8 @@ namespace Deveel.Webhooks {
 		/// <summary>
 		/// Logs the given delivery result.
 		/// </summary>
-		/// <param name="eventInfo">
-		/// The information about the event that triggered the notification.
+		/// <param name="notification">
+		/// The aggregate of the events that are being delivered to the receiver.
 		/// </param>
 		/// <param name="subscription">
 		/// The subscription that was used to send the webhook.

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
@@ -60,8 +60,6 @@ namespace Deveel.Webhooks {
 				Services.TryAddSingleton(factoryType);
 			}
 
-			Services.AddSingleton(Options.Create(new WebhookFactoryOptions<TWebhook>()));
-
 			// TODO: register the default filter evaluator
 		}
 
@@ -102,7 +100,7 @@ namespace Deveel.Webhooks {
 		/// <returns>
 		/// Returns an instance of the builder to allow chaining.
 		/// </returns>
-		public WebhookNotifierBuilder<TWebhook> UseDefaultSender() 
+		public WebhookNotifierBuilder<TWebhook> UseSender() 
 			=> UseSender((WebhookSenderBuilder<TWebhook> builder) => { });
 
 		/// <summary>
@@ -191,6 +189,37 @@ namespace Deveel.Webhooks {
 
 			Services.TryAdd(new ServiceDescriptor(typeof(IWebhookFactory<TWebhook>), typeof(TFactory), lifetime));
 			Services.Add(new ServiceDescriptor(typeof(TFactory), typeof(TFactory), lifetime));
+
+			return this;
+		}
+
+		public WebhookNotifierBuilder<TWebhook> UseWebhookFactory() {
+			if (!typeof(TWebhook).IsClass || typeof(TWebhook).IsAbstract)
+				throw new InvalidOperationException("The webhook type must be a concrete class");
+
+			// TODO: check if the TWebhook has a parameterless constructor
+			if (!(typeof(TWebhook).GetConstructor(Type.EmptyTypes)?.IsPublic ?? false))
+				throw new InvalidOperationException("The webhook type must have a public parameterless constructor");
+
+			Services.RemoveAll<IWebhookFactory<TWebhook>>();
+
+			var factoryType = typeof(DefaultWebhookFactory<>).MakeGenericType(typeof(TWebhook));
+			Services.AddSingleton(typeof(IWebhookFactory<TWebhook>), factoryType);
+			Services.AddSingleton(factoryType);
+
+			if (typeof(TWebhook).IsAssignableFrom(typeof(Webhook))) {
+				Services.AddSingleton(typeof(DefaultWebhookFactory));
+			}
+
+			return this;
+		}
+
+		public WebhookNotifierBuilder<TWebhook> UseWebhookFactory(Action<WebhookFactoryOptions<TWebhook>> configure) {
+			UseWebhookFactory();
+			if (configure != null) {
+				Services.AddOptions<WebhookFactoryOptions<TWebhook>>()
+					.Configure(configure);
+			}
 
 			return this;
 		}

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierBuilder.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Deveel.Webhooks {
 	/// <summary>
@@ -58,6 +59,8 @@ namespace Deveel.Webhooks {
 				Services.TryAddSingleton(typeof(IWebhookFactory<TWebhook>), factoryType);
 				Services.TryAddSingleton(factoryType);
 			}
+
+			Services.AddSingleton(Options.Create(new WebhookFactoryOptions<TWebhook>()));
 
 			// TODO: register the default filter evaluator
 		}

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierExtensions.cs
@@ -1,5 +1,43 @@
-﻿namespace Deveel.Webhooks {
+﻿// Copyright 2022-2024 Antonello Provenzano
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Deveel.Webhooks {
+	/// <summary>
+	/// Extensions for <see cref="IWebhookNotifier{TWebhook}"/> to notify
+	/// a single event to the subscribers.
+	/// </summary>
 	public static class WebhookNotifierExtensions {
+		/// <summary>
+		/// Notifies the given event to the subscribers.
+		/// </summary>
+		/// <typeparam name="TWebhook">
+		/// The type of the webhook to be notified.
+		/// </typeparam>
+		/// <param name="notifier">
+		/// The instance of the notifier service used to deliver
+		/// the notification.
+		/// </param>
+		/// <param name="eventInfo">
+		/// The event to be notified to the subscribers.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token that can be used to cancel the notification.
+		/// </param>
+		/// <returns>
+		/// Returns the result of the notification that contains
+		/// a single event.
+		/// </returns>
 		public static Task<WebhookNotificationResult<TWebhook>> NotifyAsync<TWebhook>(this IWebhookNotifier<TWebhook> notifier, EventInfo eventInfo, CancellationToken cancellationToken = default)
 			where TWebhook : class {
 			return notifier.NotifyAsync(new EventNotification(eventInfo), cancellationToken);

--- a/src/Deveel.Webhooks/Webhooks/WebhookNotifierExtensions.cs
+++ b/src/Deveel.Webhooks/Webhooks/WebhookNotifierExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Deveel.Webhooks {
+	public static class WebhookNotifierExtensions {
+		public static Task<WebhookNotificationResult<TWebhook>> NotifyAsync<TWebhook>(this IWebhookNotifier<TWebhook> notifier, EventInfo eventInfo, CancellationToken cancellationToken = default)
+			where TWebhook : class {
+			return notifier.NotifyAsync(new EventNotification(eventInfo), cancellationToken);
+		}
+	}
+}

--- a/test/Deveel.Webhooks.DeliveryResultLogging.Tests/Webhooks/DeliveryResultLoggerTestSuite.cs
+++ b/test/Deveel.Webhooks.DeliveryResultLogging.Tests/Webhooks/DeliveryResultLoggerTestSuite.cs
@@ -70,6 +70,8 @@ namespace Deveel.Webhooks {
 		public async Task LogSuccessfulDelivery() {
 			var webhook = WebhookFaker.Generate();
 			var eventInfo = new EventInfo("test", "executed", "1.0.0", new { name = "logTest" });
+			var notification = new EventNotification(eventInfo);
+
 			var subscription = SubscriptionFaker.Generate();
 			var destination = subscription.AsDestination();
 
@@ -83,7 +85,7 @@ namespace Deveel.Webhooks {
 			Assert.Equal(200, result.Attempts[0].ResponseCode);
 			Assert.Equal("OK", result.Attempts[0].ResponseMessage);
 			
-			await ResultLogger.LogResultAsync(eventInfo, subscription, result);
+			await ResultLogger.LogResultAsync(notification, subscription, result);
 
 			var logged = await FindResultByOperationIdAsync(result.OperationId);
 
@@ -101,6 +103,7 @@ namespace Deveel.Webhooks {
 		public async Task LogFailedDelivery() {
 			var webhook = WebhookFaker.Generate();
 			var eventInfo = new EventInfo("test", "executed", "1.0.0", new { name = "logTest" });
+			var notification = new EventNotification(eventInfo);
 			var subscription = SubscriptionFaker.Generate();
 			var destination = subscription.AsDestination();
 
@@ -126,7 +129,7 @@ namespace Deveel.Webhooks {
 			Assert.Equal(200, result.Attempts[2].ResponseCode);
 			Assert.Equal("OK", result.Attempts[2].ResponseMessage);
 
-			await ResultLogger.LogResultAsync(eventInfo, subscription, result);
+			await ResultLogger.LogResultAsync(notification, subscription, result);
 
 			var logged = await FindResultByOperationIdAsync(result.OperationId);
 

--- a/test/Deveel.Webhooks.XUnit/Webhooks/EventInfoTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/EventInfoTests.cs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 using Xunit;
 
 namespace Deveel.Webhooks {

--- a/test/Deveel.Webhooks.XUnit/Webhooks/EventNotificationTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/EventNotificationTests.cs
@@ -8,7 +8,6 @@ namespace Deveel.Webhooks {
 			var notification = new EventNotification(eventInfo);
 
 			Assert.Equal("test.event", notification.EventType);
-			Assert.True(notification.HasSingleEvent);
 			Assert.Single(notification.Events);
 			Assert.Equal(eventInfo, notification.Events[0]);
 			Assert.Single(notification);

--- a/test/Deveel.Webhooks.XUnit/Webhooks/EventNotificationTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/EventNotificationTests.cs
@@ -1,13 +1,14 @@
 ﻿using Xunit;
 
 namespace Deveel.Webhooks {
-	public static class WebhookNotificationTests {
+	public static class EventNotificationTests {
 		[Fact]
 		public static void NewNotification_OneEvent() {
 			var eventInfo = new EventInfo("subj1", "test.event");
 			var notification = new EventNotification(eventInfo);
 
 			Assert.Equal("test.event", notification.EventType);
+			Assert.True(notification.HasSingleEvent);
 			Assert.Single(notification.Events);
 			Assert.Equal(eventInfo, notification.Events[0]);
 			Assert.Single(notification);

--- a/test/Deveel.Webhooks.XUnit/Webhooks/NotifyOneWebhookPerEventTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/NotifyOneWebhookPerEventTests.cs
@@ -1,0 +1,158 @@
+﻿using System.Net.Http.Json;
+using System.Net;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit.Abstractions;
+using System.Text.Json;
+using Xunit;
+
+namespace Deveel.Webhooks {
+	public class NotifyOneWebhookPerEventTests : WebhookServiceTestBase {
+		private TestSubscriptionResolver subscriptionResolver;
+		private IWebhookNotifier<Webhook> notifier;
+
+		private IList<Webhook> lastWebhooks;
+		private HttpResponseMessage? testResponse;
+
+		public NotifyOneWebhookPerEventTests(ITestOutputHelper outputHelper) : base(outputHelper) {
+			notifier = Services.GetRequiredService<IWebhookNotifier<Webhook>>();
+			subscriptionResolver = Services.GetRequiredService<TestSubscriptionResolver>();
+		}
+
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddWebhookNotifier<Webhook>(notifier => notifier
+				.UseWebhookFactory(options => options.CreateStrategy = WebhookCreateStrategy.OnePerEvent)
+				.UseLinqFilter()
+				.UseSubscriptionResolver<TestSubscriptionResolver>(ServiceLifetime.Singleton)
+				.UseSender());
+
+			base.ConfigureServices(services);
+		}
+
+		protected override async Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {
+			try {
+				if (lastWebhooks == null)
+					lastWebhooks = new List<Webhook>();
+
+				var webhook = await httpRequest.Content!.ReadFromJsonAsync<Webhook>();
+				if (webhook != null)
+					lastWebhooks.Add(webhook);
+
+				return new HttpResponseMessage(HttpStatusCode.Accepted);
+			} catch (Exception) {
+				return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+			}
+		}
+
+		private string CreateSubscription(string name, string eventType, params WebhookFilter[] filters) {
+			return CreateSubscription(new TestWebhookSubscription {
+				EventTypes = new[] { eventType },
+				DestinationUrl = "https://callback.example.com/webhook",
+				Name = name,
+				RetryCount = 3,
+				Filters = filters,
+				Status = WebhookSubscriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow
+			}, true);
+		}
+
+		private string CreateSubscription(TestWebhookSubscription subscription, bool enabled = true) {
+			var id = Guid.NewGuid().ToString();
+
+			subscription.SubscriptionId = id;
+
+			subscriptionResolver.AddSubscription(subscription);
+
+			return id;
+		}
+
+		[Fact]
+		public async Task DeliverWebhookFromSingleEvent() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
+			var eventInfo = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(eventInfo, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+			Assert.True(result.HasSuccessful);
+			Assert.False(result.HasFailed);
+			Assert.NotEmpty(result.Successful);
+			Assert.Empty(result.Failed);
+
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.True(webhookResult.HasAttempted);
+			Assert.Single(webhookResult.Attempts);
+			Assert.NotNull(webhookResult.LastAttempt);
+			Assert.True(webhookResult.LastAttempt.HasResponse);
+
+			Assert.NotNull(lastWebhooks);
+			Assert.Single(lastWebhooks);
+			Assert.Equal("data.created", lastWebhooks[0].EventType);
+			Assert.Equal(eventInfo.Id, lastWebhooks[0].Id);
+			Assert.Equal(eventInfo.TimeStamp.ToUnixTimeSeconds(), lastWebhooks[0].TimeStamp.ToUnixTimeSeconds());
+
+			var testData = Assert.IsType<JsonElement>(lastWebhooks[0].Data);
+
+			Assert.Equal("test", testData.GetProperty("type").GetString());
+		}
+
+		[Fact]
+		public async Task DeliverWebhookFromMultipleEvents() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type.startsWith(\"test\")", "linq"));
+			EventNotification notification = new[] {
+				new EventInfo("test", "data.created", data: new {
+					creationTime = DateTimeOffset.UtcNow,
+					type = "test"
+				}),
+				new EventInfo("test", "data.created", data: new {
+					creationTime = DateTimeOffset.UtcNow.AddSeconds(3),
+					type = "test2"
+				})
+			};
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+			Assert.True(result.HasSuccessful);
+			Assert.False(result.HasFailed);
+			Assert.NotEmpty(result.Successful);
+			Assert.Empty(result.Failed);
+
+			Assert.Equal(2, result[subscriptionId]!.Count);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.True(webhookResult.HasAttempted);
+			Assert.Single(webhookResult.Attempts);
+			Assert.NotNull(webhookResult.LastAttempt);
+			Assert.True(webhookResult.LastAttempt.HasResponse);
+
+			Assert.NotNull(lastWebhooks);
+			Assert.Equal(2, lastWebhooks.Count);
+			Assert.Equal("data.created", lastWebhooks[0].EventType);
+			Assert.Equal(notification.Events[0].Id, lastWebhooks[0].Id);
+			// TODO: how to determine the timestamp of the notification that has multiple events?
+			// Assert.Equal(notification.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
+
+			var testData = Assert.IsType<JsonElement>(lastWebhooks[0].Data);
+
+			Assert.Equal("test", testData.GetProperty("type").GetString());
+		}
+
+	}
+}

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotificationTests.cs
@@ -1,364 +1,45 @@
-﻿// Copyright 2022-2024 Antonello Provenzano
-// 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
-
-using Microsoft.Extensions.DependencyInjection;
-
-using Xunit;
-using Xunit.Abstractions;
+﻿using Xunit;
 
 namespace Deveel.Webhooks {
-	public class WebhookNotificationTests : WebhookServiceTestBase {
-		private const int TimeOutSeconds = 2;
-		private bool testTimeout = false;
+	public static class WebhookNotificationTests {
+		[Fact]
+		public static void NewNotification_OneEvent() {
+			var eventInfo = new EventInfo("subj1", "test.event");
+			var notification = new EventNotification(eventInfo);
 
-		private TestSubscriptionResolver subscriptionResolver;
-		private IWebhookNotifier<Webhook> notifier;
-
-		private Webhook? lastWebhook;
-		private HttpResponseMessage? testResponse;
-
-		public WebhookNotificationTests(ITestOutputHelper outputHelper) : base(outputHelper) {
-			notifier = Services.GetRequiredService<IWebhookNotifier<Webhook>>();
-			subscriptionResolver = Services.GetRequiredService<TestSubscriptionResolver>();
-		}
-
-		protected override void ConfigureServices(IServiceCollection services) {
-			services.AddWebhookNotifier<Webhook>(config => config
-					.UseLinqFilter()
-					.UseSubscriptionResolver<TestSubscriptionResolver>(ServiceLifetime.Singleton)
-					.UseSender(options => {
-						options.Retry.MaxRetries = 2;
-						options.Retry.Timeout = TimeSpan.FromSeconds(TimeOutSeconds);
-					}));
-
-			base.ConfigureServices(services);
-		}
-
-		protected override async Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {
-			try {
-				if (testTimeout) {
-					await Task.Delay(TimeSpan.FromSeconds(TimeOutSeconds + 2));
-					return new HttpResponseMessage(HttpStatusCode.RequestTimeout);
-				}
-
-				lastWebhook = await httpRequest.Content!.ReadFromJsonAsync<Webhook>();
-
-				if (testResponse != null)
-					return testResponse;
-
-				return new HttpResponseMessage(HttpStatusCode.Accepted);
-			} catch (Exception) {
-				return new HttpResponseMessage(HttpStatusCode.InternalServerError);
-			}
-		}
-
-		private string CreateSubscription(string name, string eventType, params WebhookFilter[] filters) {
-			return CreateSubscription(new TestWebhookSubscription {
-				EventTypes = new[] { eventType },
-				DestinationUrl = "https://callback.example.com/webhook",
-				Name = name,
-				RetryCount = 3,
-				Filters = filters,
-				Status = WebhookSubscriptionStatus.Active,
-				CreatedAt = DateTimeOffset.UtcNow
-			}, true);
-		}
-
-		private string CreateSubscription(TestWebhookSubscription subscription, bool enabled = true) {
-			var id = Guid.NewGuid().ToString();
-
-			subscription.SubscriptionId = id;
-
-			subscriptionResolver.AddSubscription(subscription);
-
-			return id;
+			Assert.Equal("test.event", notification.EventType);
+			Assert.Single(notification.Events);
+			Assert.Equal(eventInfo, notification.Events[0]);
+			Assert.Single(notification);
 		}
 
 		[Fact]
-		public async Task DeliverWebhookFromEvent() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
+		public static void NewNotification_MultipleEvents() {
+			var eventInfo1 = new EventInfo("subj1", "test.event");
+			var eventInfo2 = new EventInfo("subj2", "test.event");
+			var notification = new EventNotification("test.event", new[] {eventInfo1, eventInfo2});
 
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-			Assert.True(result.HasSuccessful);
-			Assert.False(result.HasFailed);
-			Assert.NotEmpty(result.Successful);
-			Assert.Empty(result.Failed);
-
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.True(webhookResult.Successful);
-			Assert.True(webhookResult.HasAttempted);
-			Assert.Single(webhookResult.Attempts);
-			Assert.NotNull(webhookResult.LastAttempt);
-			Assert.True(webhookResult.LastAttempt.HasResponse);
-
-			Assert.NotNull(lastWebhook);
-			Assert.Equal("data.created", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
-
-			var testData = Assert.IsType<JsonElement>(lastWebhook.Data);
-
-			Assert.Equal("test", testData.GetProperty("type").GetString());
+			Assert.Equal("test.event", notification.EventType);
+			Assert.Equal(2, notification.Events.Count);
+			Assert.Equal(eventInfo1, notification.Events[0]);
+			Assert.Equal(eventInfo2, notification.Events[1]);
 		}
 
 		[Fact]
-		public async Task DeliverWebhookFromEvent_NoTransformations() {
-			var subscriptionId = CreateSubscription("Data Modified", "data.modified");
-			var notification = new EventInfo("test", "data.modified", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.True(result.HasSuccessful);
-			Assert.False(result.HasFailed);
-			Assert.NotEmpty(result.Successful);
-			Assert.Empty(result.Failed);
-
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.True(webhookResult.HasAttempted);
-			Assert.True(webhookResult.Successful);
-			Assert.Single(webhookResult.Attempts);
-			Assert.NotNull(webhookResult.LastAttempt);
-			Assert.True(webhookResult.LastAttempt.HasResponse);
-
-			Assert.NotNull(lastWebhook);
-			Assert.Equal("data.modified", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
-
-			var eventData = Assert.IsType<JsonElement>(lastWebhook.Data);
-
-			Assert.Equal("test", eventData.GetProperty("type").GetString());
-			Assert.True(eventData.TryGetProperty("creationTime", out var creationTime));
-		}
-
-
-		[Fact]
-		public async Task DeliverWebhookWithMultipleFiltersFromEvent() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created",
-				new WebhookFilter("hook.data.type == \"test\"", "linq"),
-				new WebhookFilter("hook.data.creator.user_name == \"antonello\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
-				creator = new {
-					user_name = "antonello"
-				},
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-
-			Assert.NotNull(result[subscriptionId]);
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.True(webhookResult.Successful);
-			Assert.Single(webhookResult.Attempts);
-
-			Assert.NotNull(lastWebhook);
-			Assert.Equal("data.created", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
-		}
-
-
-		[Fact]
-		public async Task DeliverWebhookWithoutFilter() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created");
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-
-			Assert.NotNull(result[subscriptionId]);
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.True(webhookResult.Successful);
-			Assert.Single(webhookResult.Attempts);
-
-			Assert.NotNull(lastWebhook);
-			Assert.Equal("data.created", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
+		public static void NewNotification_InvalidEventType() {
+			var eventInfo1 = new EventInfo("subj1", "test.event");
+			var eventInfo2 = new EventInfo("subj2", "test.event");
+			Assert.Throws<ArgumentException>(() => new EventNotification("test.event2", new[] {eventInfo1, eventInfo2}));
 		}
 
 		[Fact]
-		public async Task DeliverWenhookWithFilterTypeNotRegistered() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created",
-						new WebhookFilter("hook.data.type == \"test\"", "query"),
-						new WebhookFilter("hook.data.creator.user_name == \"antonello\"", "query"));
-
-			var notification = new EventInfo("test", "data.created", data: new {
-				creator = new {
-					user_name = "antonello"
-				},
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-			Assert.NotNull(result);
-			Assert.Empty(result);
+		public static void NewNotification_EmptyEvents() {
+			Assert.Throws<ArgumentException>(() => new EventNotification("test.event", Array.Empty<EventInfo>()));
 		}
 
 		[Fact]
-		public async Task DeliverSignedWebhookFromEvent() {
-			var subscriptionId = CreateSubscription(new TestWebhookSubscription {
-				EventTypes = new[] { "data.created" },
-				DestinationUrl = "https://callback.example.com",
-				Filters = new[] { new WebhookFilter("hook.data.type == \"test\"", "linq") },
-				Name = "Data Created",
-				Secret = "abc12345",
-				RetryCount = 3,
-				Status = WebhookSubscriptionStatus.Active
-			});
-
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-
-			Assert.NotNull(result[subscriptionId]);
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.True(webhookResult.Successful);
-			Assert.Single(webhookResult.Attempts);
-
-			Assert.NotNull(lastWebhook);
-			Assert.Equal("data.created", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
-		}
-
-		[Fact]
-		public async Task FailToDeliver() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			testResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-			Assert.NotEmpty(result.Failed);
-			Assert.True(result.HasFailed);
-
-			Assert.NotNull(result[subscriptionId]);
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.False(webhookResult.Successful);
-			Assert.Equal(3, webhookResult.Attempts.Count);
-			Assert.Equal((int)HttpStatusCode.InternalServerError, webhookResult.Attempts[0].ResponseCode);
-		}
-
-		[Fact]
-		public async Task TimeOutWhileDelivering() {
-			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			testTimeout = true;
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.NotEmpty(result);
-			Assert.Single(result);
-
-			Assert.NotNull(result[subscriptionId]);
-			Assert.Single(result[subscriptionId]!);
-
-			var webhookResult = result[subscriptionId]![0];
-
-			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
-			Assert.False(webhookResult.Successful);
-			Assert.Equal(3, webhookResult.Attempts.Count);
-			Assert.Equal((int)HttpStatusCode.RequestTimeout, webhookResult.Attempts.ElementAt(0).ResponseCode);
-		}
-
-
-
-		[Fact]
-		public async Task NoSubscriptionMatches() {
-			CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test-data2\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
-				creationTime = DateTimeOffset.UtcNow,
-				type = "test"
-			});
-
-			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
-
-			Assert.NotNull(result);
-			Assert.Empty(result);
+		public static void NewNotification_EmptyEventType() {
+			Assert.Throws<ArgumentException>(() => new EventNotification("", new[] {new EventInfo("sub1", "test.event")}));
 		}
 	}
 }

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
@@ -90,12 +90,57 @@ namespace Deveel.Webhooks {
 		}
 
 		[Fact]
-		public async Task DeliverWebhookFromEvent() {
+		public async Task DeliverWebhookFromSingleEvent() {
 			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
-			var notification = new EventInfo("test", "data.created", data: new {
+			var eventInfo = new EventInfo("test", "data.created", data: new {
 				creationTime = DateTimeOffset.UtcNow,
 				type = "test"
 			});
+
+			var result = await notifier.NotifyAsync(eventInfo, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+			Assert.True(result.HasSuccessful);
+			Assert.False(result.HasFailed);
+			Assert.NotEmpty(result.Successful);
+			Assert.Empty(result.Failed);
+
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.True(webhookResult.HasAttempted);
+			Assert.Single(webhookResult.Attempts);
+			Assert.NotNull(webhookResult.LastAttempt);
+			Assert.True(webhookResult.LastAttempt.HasResponse);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.created", lastWebhook.EventType);
+			Assert.Equal(eventInfo.Id, lastWebhook.Id);
+			Assert.Equal(eventInfo.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
+
+			var testData = Assert.IsType<JsonElement>(lastWebhook.Data);
+
+			Assert.Equal("test", testData.GetProperty("type").GetString());
+		}
+
+		[Fact]
+		public async Task DeliverWebhookFromMultipleEvents() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data[0].type.equals(\"test\")", "linq"));
+			EventNotification notification = new[] {
+				new EventInfo("test", "data.created", data: new {
+					creationTime = DateTimeOffset.UtcNow,
+					type = "test"
+				}),
+				new EventInfo("test", "data.created", data: new {
+					creationTime = DateTimeOffset.UtcNow.AddSeconds(3),
+					type = "test2"
+				})
+			};
 
 			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
 
@@ -120,13 +165,17 @@ namespace Deveel.Webhooks {
 
 			Assert.NotNull(lastWebhook);
 			Assert.Equal("data.created", lastWebhook.EventType);
-			Assert.Equal(notification.Id, lastWebhook.Id);
-			Assert.Equal(notification.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
+			Assert.Equal(notification.NotificationId, lastWebhook.Id);
+			// TODO: how to determine the timestamp of the notification that has multiple events?
+			// Assert.Equal(notification.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
 
 			var testData = Assert.IsType<JsonElement>(lastWebhook.Data);
 
-			Assert.Equal("test", testData.GetProperty("type").GetString());
+			Assert.Equal(JsonValueKind.Array, testData.ValueKind);
+			Assert.Equal(2, testData.GetArrayLength());
+			Assert.Equal("test", testData[0].GetProperty("type").GetString());
 		}
+
 
 		[Fact]
 		public async Task DeliverWebhookFromEvent_NoTransformations() {

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
@@ -38,7 +38,7 @@ namespace Deveel.Webhooks {
 		}
 
 		protected override void ConfigureServices(IServiceCollection services) {
-			services.AddWebhookNotifier<Webhook>(config => config
+			services.AddWebhookNotifier<Webhook>(notifier => notifier
 					.UseLinqFilter()
 					.UseSubscriptionResolver<TestSubscriptionResolver>(ServiceLifetime.Singleton)
 					.UseSender(options => {

--- a/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
+++ b/test/Deveel.Webhooks.XUnit/Webhooks/WebhookNotifierTests.cs
@@ -1,0 +1,364 @@
+﻿// Copyright 2022-2024 Antonello Provenzano
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks {
+	public class WebhookNotifierTests : WebhookServiceTestBase {
+		private const int TimeOutSeconds = 2;
+		private bool testTimeout = false;
+
+		private TestSubscriptionResolver subscriptionResolver;
+		private IWebhookNotifier<Webhook> notifier;
+
+		private Webhook? lastWebhook;
+		private HttpResponseMessage? testResponse;
+
+		public WebhookNotifierTests(ITestOutputHelper outputHelper) : base(outputHelper) {
+			notifier = Services.GetRequiredService<IWebhookNotifier<Webhook>>();
+			subscriptionResolver = Services.GetRequiredService<TestSubscriptionResolver>();
+		}
+
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddWebhookNotifier<Webhook>(config => config
+					.UseLinqFilter()
+					.UseSubscriptionResolver<TestSubscriptionResolver>(ServiceLifetime.Singleton)
+					.UseSender(options => {
+						options.Retry.MaxRetries = 2;
+						options.Retry.Timeout = TimeSpan.FromSeconds(TimeOutSeconds);
+					}));
+
+			base.ConfigureServices(services);
+		}
+
+		protected override async Task<HttpResponseMessage> OnRequestAsync(HttpRequestMessage httpRequest) {
+			try {
+				if (testTimeout) {
+					await Task.Delay(TimeSpan.FromSeconds(TimeOutSeconds + 2));
+					return new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+				}
+
+				lastWebhook = await httpRequest.Content!.ReadFromJsonAsync<Webhook>();
+
+				if (testResponse != null)
+					return testResponse;
+
+				return new HttpResponseMessage(HttpStatusCode.Accepted);
+			} catch (Exception) {
+				return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+			}
+		}
+
+		private string CreateSubscription(string name, string eventType, params WebhookFilter[] filters) {
+			return CreateSubscription(new TestWebhookSubscription {
+				EventTypes = new[] { eventType },
+				DestinationUrl = "https://callback.example.com/webhook",
+				Name = name,
+				RetryCount = 3,
+				Filters = filters,
+				Status = WebhookSubscriptionStatus.Active,
+				CreatedAt = DateTimeOffset.UtcNow
+			}, true);
+		}
+
+		private string CreateSubscription(TestWebhookSubscription subscription, bool enabled = true) {
+			var id = Guid.NewGuid().ToString();
+
+			subscription.SubscriptionId = id;
+
+			subscriptionResolver.AddSubscription(subscription);
+
+			return id;
+		}
+
+		[Fact]
+		public async Task DeliverWebhookFromEvent() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+			Assert.True(result.HasSuccessful);
+			Assert.False(result.HasFailed);
+			Assert.NotEmpty(result.Successful);
+			Assert.Empty(result.Failed);
+
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.True(webhookResult.HasAttempted);
+			Assert.Single(webhookResult.Attempts);
+			Assert.NotNull(webhookResult.LastAttempt);
+			Assert.True(webhookResult.LastAttempt.HasResponse);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.created", lastWebhook.EventType);
+			Assert.Equal(notification.Id, lastWebhook.Id);
+			Assert.Equal(notification.TimeStamp.ToUnixTimeSeconds(), lastWebhook.TimeStamp.ToUnixTimeSeconds());
+
+			var testData = Assert.IsType<JsonElement>(lastWebhook.Data);
+
+			Assert.Equal("test", testData.GetProperty("type").GetString());
+		}
+
+		[Fact]
+		public async Task DeliverWebhookFromEvent_NoTransformations() {
+			var subscriptionId = CreateSubscription("Data Modified", "data.modified");
+			var notification = new EventInfo("test", "data.modified", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.True(result.HasSuccessful);
+			Assert.False(result.HasFailed);
+			Assert.NotEmpty(result.Successful);
+			Assert.Empty(result.Failed);
+
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.HasAttempted);
+			Assert.True(webhookResult.Successful);
+			Assert.Single(webhookResult.Attempts);
+			Assert.NotNull(webhookResult.LastAttempt);
+			Assert.True(webhookResult.LastAttempt.HasResponse);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.modified", lastWebhook.EventType);
+			Assert.Equal(notification.Id, lastWebhook.Id);
+			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
+
+			var eventData = Assert.IsType<JsonElement>(lastWebhook.Data);
+
+			Assert.Equal("test", eventData.GetProperty("type").GetString());
+			Assert.True(eventData.TryGetProperty("creationTime", out var creationTime));
+		}
+
+
+		[Fact]
+		public async Task DeliverWebhookWithMultipleFiltersFromEvent() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created",
+				new WebhookFilter("hook.data.type == \"test\"", "linq"),
+				new WebhookFilter("hook.data.creator.user_name == \"antonello\"", "linq"));
+			var notification = new EventInfo("test", "data.created", data: new {
+				creator = new {
+					user_name = "antonello"
+				},
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+
+			Assert.NotNull(result[subscriptionId]);
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.Single(webhookResult.Attempts);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.created", lastWebhook.EventType);
+			Assert.Equal(notification.Id, lastWebhook.Id);
+			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
+		}
+
+
+		[Fact]
+		public async Task DeliverWebhookWithoutFilter() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created");
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+
+			Assert.NotNull(result[subscriptionId]);
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.Single(webhookResult.Attempts);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.created", lastWebhook.EventType);
+			Assert.Equal(notification.Id, lastWebhook.Id);
+			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
+		}
+
+		[Fact]
+		public async Task DeliverWenhookWithFilterTypeNotRegistered() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created",
+						new WebhookFilter("hook.data.type == \"test\"", "query"),
+						new WebhookFilter("hook.data.creator.user_name == \"antonello\"", "query"));
+
+			var notification = new EventInfo("test", "data.created", data: new {
+				creator = new {
+					user_name = "antonello"
+				},
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+			Assert.NotNull(result);
+			Assert.Empty(result);
+		}
+
+		[Fact]
+		public async Task DeliverSignedWebhookFromEvent() {
+			var subscriptionId = CreateSubscription(new TestWebhookSubscription {
+				EventTypes = new[] { "data.created" },
+				DestinationUrl = "https://callback.example.com",
+				Filters = new[] { new WebhookFilter("hook.data.type == \"test\"", "linq") },
+				Name = "Data Created",
+				Secret = "abc12345",
+				RetryCount = 3,
+				Status = WebhookSubscriptionStatus.Active
+			});
+
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+
+			Assert.NotNull(result[subscriptionId]);
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.True(webhookResult.Successful);
+			Assert.Single(webhookResult.Attempts);
+
+			Assert.NotNull(lastWebhook);
+			Assert.Equal("data.created", lastWebhook.EventType);
+			Assert.Equal(notification.Id, lastWebhook.Id);
+			Assert.Equal(notification.TimeStamp.ToUnixTimeMilliseconds(), lastWebhook.TimeStamp.ToUnixTimeMilliseconds());
+		}
+
+		[Fact]
+		public async Task FailToDeliver() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			testResponse = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+			Assert.NotEmpty(result.Failed);
+			Assert.True(result.HasFailed);
+
+			Assert.NotNull(result[subscriptionId]);
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.False(webhookResult.Successful);
+			Assert.Equal(3, webhookResult.Attempts.Count);
+			Assert.Equal((int)HttpStatusCode.InternalServerError, webhookResult.Attempts[0].ResponseCode);
+		}
+
+		[Fact]
+		public async Task TimeOutWhileDelivering() {
+			var subscriptionId = CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test\"", "linq"));
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			testTimeout = true;
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.NotEmpty(result);
+			Assert.Single(result);
+
+			Assert.NotNull(result[subscriptionId]);
+			Assert.Single(result[subscriptionId]!);
+
+			var webhookResult = result[subscriptionId]![0];
+
+			Assert.Equal(subscriptionId, webhookResult.Webhook.SubscriptionId);
+			Assert.False(webhookResult.Successful);
+			Assert.Equal(3, webhookResult.Attempts.Count);
+			Assert.Equal((int)HttpStatusCode.RequestTimeout, webhookResult.Attempts.ElementAt(0).ResponseCode);
+		}
+
+
+
+		[Fact]
+		public async Task NoSubscriptionMatches() {
+			CreateSubscription("Data Created", "data.created", new WebhookFilter("hook.data.type == \"test-data2\"", "linq"));
+			var notification = new EventInfo("test", "data.created", data: new {
+				creationTime = DateTimeOffset.UtcNow,
+				type = "test"
+			});
+
+			var result = await notifier.NotifyAsync(notification, CancellationToken.None);
+
+			Assert.NotNull(result);
+			Assert.Empty(result);
+		}
+	}
+}


### PR DESCRIPTION
Adding the support to send webhooks on batches of events:
* Definition of the _EventNotification_ type that aggregates multiple events of the same type
* Webhook factories contract accepting EventNotification to build arrays of webhooks
* Webhook factory strategy to generate one webhook for multiple events, or one webhook per event in the notification