### PR TITLE
Fixes to Entity Framework Configuration Bug #64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnet: [ '6.0.x', '7.0.x' ]
+        dotnet: [ '6.0.x', '7.0.x', '8.0.x' ]
         os: [ ubuntu-latest, windows-latest ]
     
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,8 +48,14 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release -f ${{ env.DOTNET_TFM }}
     
-    - name: Test
+    - name: Test (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
       run: dotnet test --no-build --verbosity normal -c  Release -f ${{ env.DOTNET_TFM }} /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.XUnit]*"
+
+    - name: Test (Ubuntu)
+      if: matrix.os == 'windows-latest'
+      run: dotnet test --no-build --verbosity normal -c  Release -f ${{ env.DOTNET_TFM }} --filter DB=SQLServer /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.XUnit]*"
+
       
     - name: Collect to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Test (Ubuntu)
       if: matrix.os == 'windows-latest'
-      run: dotnet test --no-build --verbosity normal -c  Release -f ${{ env.DOTNET_TFM }} --filter DB=SQLServer /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.XUnit]*"
+      run: dotnet test --no-build --verbosity normal -c  Release -f ${{ env.DOTNET_TFM }} --filter DB!=SQLServer /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.XUnit]*"
 
       
     - name: Collect to Codecov

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        dotnet: [ '6.0.x', '7.0.x' ]
+        dotnet: [ '6.0.x', '7.0.x', '8.0.x' ]
         os: [ ubuntu-latest, windows-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,17 +27,44 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
           
-    - name: Set the TFM for .NET 6.0
-      if: matrix.dotnet == '6.0.x'
-      run: echo "DOTNET_TFM=net6.0" >> $GITHUB_ENV
+    # - name: Set the TFM for .NET 6.0 (Ubuntu)
+    #   if: matrix.dotnet == '6.0.x' && matrix.os == 'ubuntu-latest'
+    #   run: echo "DOTNET_TFM=net6.0" >> $GITHUB_ENV
 
-    - name: Set the TFM for .NET 7.0
-      if: matrix.dotnet == '7.0.x'
-      run: echo "DOTNET_TFM=net7.0" >> $GITHUB_ENV
+    # - name: Set the TFM for .NET 7.0 (Ubuntu)
+    #   if: matrix.dotnet == '7.0.x' && matrix.os == 'ubuntu-latest'
+    #   run: echo "DOTNET_TFM=net7.0" >> $GITHUB_ENV
 
-    - name: Set the TFM for .NET 8.0
-      if: matrix.dotnet == '8.0.x'
-      run: echo "DOTNET_TFM=net8.0" >> $GITHUB_ENV
+    # - name: Set the TFM for .NET 8.0 (Ubuntu)
+    #   if: matrix.dotnet == '8.0.x' && matrix.os == 'ubuntu-latest'
+    #   run: echo "DOTNET_TFM=net8.0" >> $GITHUB_ENV
+
+    # - name: Set the TFM for .NET 6.0 (Windows)
+    #   if: matrix.dotnet == '6.0.x' && matrix.os == 'windows-latest'
+    #   run: echo "DOTNET_TFM=net6.0" >> $env:GITHUB_ENV
+
+    # - name: Set the TFM for .NET 7.0 (Windows)
+    #   if: matrix.dotnet == '7.0.x' && matrix.os == 'windows-latest'
+    #   run: echo "DOTNET_TFM=net7.0" >> $env:GITHUB_ENV
+
+    # - name: Set the TFM for .NET 8.0 (Windows)
+    #   if: matrix.dotnet == '8.0.x' && matrix.os == 'windows-latest'
+    #   run: echo "DOTNET_TFM=net8.0" >> $env:GITHUB_ENV
+
+    - name: Set the TFM in Ubuntu
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+          VERSION=$(echo "${{ matrix.dotnet }}" | sed 's/[^0-9.]*//g')
+          VERSION=$(echo "${VERSION}" | sed 's/\.$//')
+          DOTNET_TFM="net${VERSION}"
+          echo "DOTNET_TFM=$DOTNET_TFM" >> $GITHUB_ENV
+
+    - name: Set the TFM in Windows
+      if: startsWith(matrix.os, 'windows')
+      run: |
+          $VERSION = "${{ matrix.dotnet }}".Substring(0, "${{ matrix.dotnet }}".LastIndexOf('.'))
+          $DOTNET_TFM = "net$VERSION"
+          echo "DOTNET_TFM=$DOTNET_TFM" | Out-File -FilePath $env:GITHUB_ENV -Append
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,30 +27,6 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet }}
           
-    # - name: Set the TFM for .NET 6.0 (Ubuntu)
-    #   if: matrix.dotnet == '6.0.x' && matrix.os == 'ubuntu-latest'
-    #   run: echo "DOTNET_TFM=net6.0" >> $GITHUB_ENV
-
-    # - name: Set the TFM for .NET 7.0 (Ubuntu)
-    #   if: matrix.dotnet == '7.0.x' && matrix.os == 'ubuntu-latest'
-    #   run: echo "DOTNET_TFM=net7.0" >> $GITHUB_ENV
-
-    # - name: Set the TFM for .NET 8.0 (Ubuntu)
-    #   if: matrix.dotnet == '8.0.x' && matrix.os == 'ubuntu-latest'
-    #   run: echo "DOTNET_TFM=net8.0" >> $GITHUB_ENV
-
-    # - name: Set the TFM for .NET 6.0 (Windows)
-    #   if: matrix.dotnet == '6.0.x' && matrix.os == 'windows-latest'
-    #   run: echo "DOTNET_TFM=net6.0" >> $env:GITHUB_ENV
-
-    # - name: Set the TFM for .NET 7.0 (Windows)
-    #   if: matrix.dotnet == '7.0.x' && matrix.os == 'windows-latest'
-    #   run: echo "DOTNET_TFM=net7.0" >> $env:GITHUB_ENV
-
-    # - name: Set the TFM for .NET 8.0 (Windows)
-    #   if: matrix.dotnet == '8.0.x' && matrix.os == 'windows-latest'
-    #   run: echo "DOTNET_TFM=net8.0" >> $env:GITHUB_ENV
-
     - name: Set the TFM in Ubuntu
       if: startsWith(matrix.os, 'ubuntu')
       run: |
@@ -72,5 +48,10 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release -f ${{ env.DOTNET_TFM }}
     
-    - name: Test
+    - name: Test (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
       run: dotnet test --no-build --verbosity normal -c Release -f ${{ env.DOTNET_TFM }}
+
+    - name: Test (Windows)
+      if: matrix.os == 'windows-latest'
+      run: dotnet test --no-build --verbosity normal -c Release -f ${{ env.DOTNET_TFM }} --filter DB=SQLServer

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,4 +54,4 @@ jobs:
 
     - name: Test (Windows)
       if: matrix.os == 'windows-latest'
-      run: dotnet test --no-build --verbosity normal -c Release -f ${{ env.DOTNET_TFM }} --filter DB=SQLServer
+      run: dotnet test --no-build --verbosity normal -c Release -f ${{ env.DOTNET_TFM }} --filter DB!=SQLServer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-         dotnet: [ '6.0.x', '7.0.x' ]
+         dotnet: [ '6.0.x', '7.0.x', '8.0.x' ]
 
     steps:
     - uses: actions/checkout@v4
@@ -68,4 +68,7 @@ jobs:
       run: dotnet pack --configuration Release --include-symbols -p:PackageVersion=$VERSION --output ./nuget
 
     - name: Push Packages to GitHub NuGet
+      run: dotnet nuget push ./nuget/**/*.nupkg --skip-duplicate --api-key ${{secrets.GITHUB_TOKEN}} --source "https://nuget.pkg.github.com/deveel/index.json"
+
+    - name: Push Packages to NuGet
       run: dotnet nuget push ./nuget/**/*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/samples/WebhookNotifierApp/WebhookNotifierApp.csproj
+++ b/samples/WebhookNotifierApp/WebhookNotifierApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Deveel.Webhooks</RootNamespace>

--- a/samples/WebhookReceiverApp.MinimalApi/WebhookReceiverApp.MinimalApi.csproj
+++ b/samples/WebhookReceiverApp.MinimalApi/WebhookReceiverApp.MinimalApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Deveel.Webhooks</RootNamespace>

--- a/samples/WebhookReceiverApp/WebhookReceiverApp.csproj
+++ b/samples/WebhookReceiverApp/WebhookReceiverApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Deveel.Webhooks</RootNamespace>

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/DbWebhookDeliveryResultConfiguration.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/DbWebhookDeliveryResultConfiguration.cs
@@ -36,12 +36,20 @@ namespace Deveel.Webhooks {
                 .HasMaxLength(36)
                 .IsRequired();
 
-            builder.Property(x => x.EventId)
-                .HasColumnName("event_id")
+            builder.Property(x => x.TenantId)
+                .HasColumnName("tenant_id");
+
+            builder.Property(x => x.WebhookId)
+                .HasColumnName("webhook_id")
                 .IsRequired();
 
+            builder.Property(x => x.EventId)
+                .HasColumnName("event_id")
+                .IsRequired(false);
+
             builder.Property(x => x.ReceiverId)
-                .HasColumnName("receiver_id");
+                .HasColumnName("receiver_id")
+                .IsRequired(false);
 
             builder.HasOne(x => x.EventInfo)
                 .WithMany()
@@ -61,7 +69,7 @@ namespace Deveel.Webhooks {
             builder.HasOne(x => x.Webhook)
                 .WithMany()
                 .HasForeignKey(x => x.WebhookId)
-                .OnDelete(DeleteBehavior.SetNull);
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/EntityWebhookDeliveryResultRepository_T.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/EntityWebhookDeliveryResultRepository_T.cs
@@ -43,12 +43,39 @@ namespace Deveel.Webhooks {
 			: base(context, logger) {
         }
 
+        /// <summary>
+        /// Gets a queryable object to query the delivery results,
+        /// including the related entities (webhook, event, delivery 
+        /// attempts, receiver).
+        /// </summary>
+        /// <returns>
+        /// Returns an <see cref="IQueryable{TResult}"/> object that can be used
+        /// to query the delivery results.
+        /// </returns>
+        public override IQueryable<TResult> AsQueryable()
+        {
+            return Entities
+                .Include(x => x.Webhook)
+                .Include(x => x.EventInfo)
+                .Include(x => x.DeliveryAttempts)
+                .Include(x => x.Receiver);
+        }
+
+        /// <inheritdoc/>
+        public override async Task<TResult?> FindAsync(int key, CancellationToken cancellationToken = default)
+        {
+            // This overload to the identity key uses the 'FindAsync' method
+            // to include all the related entities
+            // TODO: find a better way to include the related entities through lazy loading
+            return await FindFirstAsync(Query.Where<TResult>(x => x.Id == key), cancellationToken);
+        }
+
         /// <inheritdoc/>
         public async Task<TResult?> FindByWebhookIdAsync(string webhookId, CancellationToken cancellationToken) {
             cancellationToken.ThrowIfCancellationRequested();
 
             try {
-                return await this.FindFirstAsync<TResult, int>(x => x.Webhook.WebhookId == webhookId, cancellationToken);
+                return await FindFirstAsync(Query.Where<TResult>(x => x.Webhook.WebhookId == webhookId), cancellationToken);
             } catch (Exception ex) {
                 throw new WebhookEntityException("Unable to query the database for results", ex);
             }

--- a/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookDbContext.cs
+++ b/src/Deveel.Webhooks.Service.EntityFramework/Webhooks/WebhookDbContext.cs
@@ -37,6 +37,12 @@ namespace Deveel.Webhooks {
 		/// </summary>
         public virtual DbSet<DbWebhookDeliveryResult> DeliveryResults { get; set; }
 
+        /// <summary>
+        /// Gets or sets the set a <c>DbSet</c> that provides query access to
+        /// the <see cref="DbWebhookDeliveryAttempt"/> entities.
+        /// </summary>
+        public virtual DbSet<DbWebhook> Webhooks { get; set; }
+
         /// <inheritdoc/>
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
             modelBuilder.ApplyConfiguration(new DbWebhookSubscriptionConfiguration());

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Deveel.Webhooks.EntityFramework.XUnit.csproj
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Deveel.Webhooks.EntityFramework.XUnit.csproj
@@ -6,15 +6,21 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.24" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.24" />
 		<PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.12" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Testcontainers.MsSql" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntitySubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntitySubscriptionResolverTests.cs
@@ -4,12 +4,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Xunit.Abstractions;
 
-using static System.Formats.Asn1.AsnWriter;
-
-namespace Deveel.Webhooks {
-	public class EntitySubscriptionResolverTests : EntityWebhookTestBase {
-		public EntitySubscriptionResolverTests(SqliteTestDatabase sqlite, ITestOutputHelper outputHelper) 
-			: base(sqlite, outputHelper) {
+namespace Deveel.Webhooks
+{
+    public abstract class EntitySubscriptionResolverTests : EntityWebhookTestBase {
+		protected EntitySubscriptionResolverTests(ITestOutputHelper outputHelper) 
+			: base(outputHelper) {
 		}
 
 		protected IList<DbWebhookSubscription> Subscriptions { get; private set; }

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookManagementTestCollection.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookManagementTestCollection.cs
@@ -1,5 +1,0 @@
-﻿namespace Deveel.Webhooks {
-	[CollectionDefinition(nameof(EntityWebhookManagementTestCollection))]
-	public class EntityWebhookManagementTestCollection : ICollectionFixture<SqliteTestDatabase> {
-	}
-}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookManagementTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/EntityWebhookManagementTests.cs
@@ -6,27 +6,21 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Deveel.Webhooks {
-	[Collection(nameof(EntityWebhookManagementTestCollection))]
-	public class EntityWebhookManagementTests : WebhookManagementTestSuite<DbWebhookSubscription, string> {
-		private readonly SqliteTestDatabase sql;
+	public abstract class EntityWebhookManagementTests : WebhookManagementTestSuite<DbWebhookSubscription, string> {
+        protected EntityWebhookManagementTests(ITestOutputHelper testOutput) : base(testOutput)
+        {
+        }
 
-		public EntityWebhookManagementTests(SqliteTestDatabase sql, ITestOutputHelper testOutput) : base(testOutput) {
-			this.sql = sql;
-		}
-
-		protected override Faker<DbWebhookSubscription> Faker => new DbWebhookSubscriptionFaker();
+        protected override Faker<DbWebhookSubscription> Faker => new DbWebhookSubscriptionFaker();
 
 		protected override string GenerateSubscriptionKey() => Guid.NewGuid().ToString();
-
-		protected override void ConfigureWebhookStorage(WebhookSubscriptionBuilder<DbWebhookSubscription, string> options)
-			=> options.UseEntityFramework(builder => builder.UseContext(ctx => ctx.UseSqlite(sql.Connection)));
 
 		protected override async Task InitializeAsync() {
 			var options = Services!.GetRequiredService<DbContextOptions<WebhookDbContext>>();
 
 			using var context = new WebhookDbContext(options);
 
-			await context.Database.EnsureDeletedAsync();
+			// await context.Database.EnsureDeletedAsync();
 			await context.Database.EnsureCreatedAsync();
 
 			await base.InitializeAsync();
@@ -39,7 +33,7 @@ namespace Deveel.Webhooks {
 			context.Subscriptions.RemoveRange(context.Subscriptions);
 			await context.SaveChangesAsync(true);
 
-			await context.Database.EnsureDeletedAsync();
+			//await context.Database.EnsureDeletedAsync();
 		}
 	}
 }

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlDeliveryResultRepositoryTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlDeliveryResultRepositoryTests.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(MsSqlTestCollection))]
+    public class MsSqlDeliveryResultRepositoryTests : EntityDeliveryResultRepositoryTests
+    {
+        private readonly MsSqlTestDatabase sql;
+
+        public MsSqlDeliveryResultRepositoryTests(MsSqlTestDatabase sql, ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+            this.sql = sql;
+        }
+
+        protected override void ConfigureWebhookEntityFramework(EntityWebhookStorageBuilder<DbWebhookSubscription> builder)
+        {
+            builder.UseContext(x => x.UseSqlServer(sql.ConnectionString));
+        }
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlDeliveryResultRepositoryTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlDeliveryResultRepositoryTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Deveel.Webhooks
 {
     [Collection(nameof(MsSqlTestCollection))]
+    [Trait("DB", "SQLServer")]
     public class MsSqlDeliveryResultRepositoryTests : EntityDeliveryResultRepositoryTests
     {
         private readonly MsSqlTestDatabase sql;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlSubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlSubscriptionResolverTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Deveel.Webhooks
 {
     [Collection(nameof(MsSqlTestCollection))]
+    [Trait("DB", "SQLServer")]
     public class MsSqlSubscriptionResolverTests : EntitySubscriptionResolverTests
     {
         private readonly MsSqlTestDatabase sql;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlSubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlSubscriptionResolverTests.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(MsSqlTestCollection))]
+    public class MsSqlSubscriptionResolverTests : EntitySubscriptionResolverTests
+    {
+        private readonly MsSqlTestDatabase sql;
+
+        public MsSqlSubscriptionResolverTests(MsSqlTestDatabase sql, ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+            this.sql = sql;
+        }
+
+        protected override void ConfigureWebhookEntityFramework(EntityWebhookStorageBuilder<DbWebhookSubscription> builder)
+        {
+            builder.UseContext(options => options.UseSqlServer(sql.ConnectionString));
+        }
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestCollection.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestCollection.cs
@@ -1,0 +1,7 @@
+﻿namespace Deveel.Webhooks
+{
+    [CollectionDefinition(nameof(MsSqlTestCollection))]
+    public class MsSqlTestCollection : ICollectionFixture<MsSqlTestDatabase>
+    {
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
@@ -13,6 +13,7 @@ namespace Deveel.Webhooks
         public MsSqlTestDatabase()
         {
             _container = new MsSqlBuilder()
+                .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
                 .Build();
         }
 

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
@@ -1,0 +1,39 @@
+﻿using DotNet.Testcontainers.Builders;
+
+using Microsoft.Data.SqlClient;
+
+using Testcontainers.MsSql;
+
+namespace Deveel.Webhooks
+{
+    public class MsSqlTestDatabase : IAsyncLifetime
+    {
+        private readonly MsSqlContainer _container;
+
+        public MsSqlTestDatabase()
+        {
+            _container = new MsSqlBuilder()
+                .Build();
+        }
+
+        public string ConnectionString
+        {
+            get
+            {
+                var builder = new SqlConnectionStringBuilder(_container.GetConnectionString());
+                builder.InitialCatalog = "webhooks_tests";
+                return builder.ConnectionString;
+            }
+        }
+
+        async Task IAsyncLifetime.DisposeAsync()
+        {
+            await _container.DisposeAsync();
+        }
+
+        async Task IAsyncLifetime.InitializeAsync()
+        {
+            await _container.StartAsync();
+        }
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
@@ -13,7 +13,7 @@ namespace Deveel.Webhooks
         public MsSqlTestDatabase()
         {
             _container = new MsSqlBuilder()
-                .WithImage("mcr.microsoft.com/mssql/server:2019-latest")
+                .WithImage("mcr.microsoft.com/mssql/server:2019-CU14-ubuntu-20.04")
                 .Build();
         }
 

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlTestDatabase.cs
@@ -13,7 +13,7 @@ namespace Deveel.Webhooks
         public MsSqlTestDatabase()
         {
             _container = new MsSqlBuilder()
-                .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+                .WithImage("mcr.microsoft.com/mssql/server:2019-latest")
                 .Build();
         }
 

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlWebhookManagementTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlWebhookManagementTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Deveel.Webhooks
 {
     [Collection(nameof(MsSqlTestCollection))]
+    [Trait("DB", "SQLServer")]
     public class MsSqlWebhookManagementTests : EntityWebhookManagementTests
     {
         private readonly MsSqlTestDatabase sql;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlWebhookManagementTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/MsSqlWebhookManagementTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(MsSqlTestCollection))]
+    public class MsSqlWebhookManagementTests : EntityWebhookManagementTests
+    {
+        private readonly MsSqlTestDatabase sql;
+
+        public MsSqlWebhookManagementTests(MsSqlTestDatabase sql, ITestOutputHelper testOutput) : base(testOutput)
+        {
+            this.sql = sql;
+        }
+
+        protected override void ConfigureWebhookStorage(WebhookSubscriptionBuilder<DbWebhookSubscription, string> options)
+            => options.UseEntityFramework(builder => builder.UseContext(ctx => ctx.UseSqlServer(sql.ConnectionString, s => s.EnableRetryOnFailure())));
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteDeliveryResultRepositoryTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteDeliveryResultRepositoryTests.cs
@@ -1,17 +1,11 @@
-﻿using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.EntityFrameworkCore;
 
 using Xunit.Abstractions;
 
 namespace Deveel.Webhooks
 {
     [Collection(nameof(SqliteTestCollection))]
+    [Trait("DB", "SQLite")]
     public class SqliteDeliveryResultRepositoryTests : EntityDeliveryResultRepositoryTests
     {
         private readonly SqliteTestDatabase sqlite;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteDeliveryResultRepositoryTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteDeliveryResultRepositoryTests.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(SqliteTestCollection))]
+    public class SqliteDeliveryResultRepositoryTests : EntityDeliveryResultRepositoryTests
+    {
+        private readonly SqliteTestDatabase sqlite;
+
+        public SqliteDeliveryResultRepositoryTests(SqliteTestDatabase sqlite, ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+            this.sqlite = sqlite;
+        }
+
+        protected override void ConfigureWebhookEntityFramework(EntityWebhookStorageBuilder<DbWebhookSubscription> builder)
+        {
+            builder.UseContext(options => options.UseSqlite(sqlite.Connection));
+        }
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteSubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteSubscriptionResolverTests.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(SqliteTestCollection))]
+    public class SqliteSubscriptionResolverTests : EntitySubscriptionResolverTests
+    {
+        private readonly SqliteTestDatabase sqlite;
+
+        public SqliteSubscriptionResolverTests(SqliteTestDatabase sqlite, ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+            this.sqlite = sqlite;
+        }
+
+        protected override void ConfigureWebhookEntityFramework(EntityWebhookStorageBuilder<DbWebhookSubscription> builder)
+        {
+            builder.UseContext(options => options.UseSqlite(sqlite.Connection));
+        }
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteSubscriptionResolverTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteSubscriptionResolverTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Deveel.Webhooks
 {
     [Collection(nameof(SqliteTestCollection))]
+    [Trait("DB", "SQLite")]
     public class SqliteSubscriptionResolverTests : EntitySubscriptionResolverTests
     {
         private readonly SqliteTestDatabase sqlite;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteTestCollection.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteTestCollection.cs
@@ -1,0 +1,5 @@
+﻿namespace Deveel.Webhooks {
+	[CollectionDefinition(nameof(SqliteTestCollection))]
+	public class SqliteTestCollection : ICollectionFixture<SqliteTestDatabase> {
+	}
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookManagementTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookManagementTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(SqliteTestCollection))]
+    public class SqliteWebhookManagementTests : EntityWebhookManagementTests
+    {
+        private readonly SqliteTestDatabase sql;
+
+        public SqliteWebhookManagementTests(SqliteTestDatabase sql, ITestOutputHelper testOutput) : base(testOutput)
+        {
+            this.sql = sql;
+        }
+
+        protected override void ConfigureWebhookStorage(WebhookSubscriptionBuilder<DbWebhookSubscription, string> options)
+            => options.UseEntityFramework(builder => builder.UseContext(ctx => ctx.UseSqlite(sql.Connection)));
+    }
+}

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookManagementTests.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookManagementTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 namespace Deveel.Webhooks
 {
     [Collection(nameof(SqliteTestCollection))]
+    [Trait("DB", "SQLite")]
     public class SqliteWebhookManagementTests : EntityWebhookManagementTests
     {
         private readonly SqliteTestDatabase sql;

--- a/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookTestBase.cs
+++ b/test/Deveel.Webhooks.EntityFramework.XUnit/Webhooks/SqliteWebhookTestBase.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Webhooks
+{
+    [Collection(nameof(EntityTestCollection))]
+    public class SqliteWebhookTestBase : EntityWebhookTestBase
+    {
+        private readonly SqliteTestDatabase sqlite;
+
+        public SqliteWebhookTestBase(SqliteTestDatabase sqlite, ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+            this.sqlite = sqlite;
+        }
+
+        protected override void ConfigureWebhookEntityFramework(EntityWebhookStorageBuilder<DbWebhookSubscription> builder)
+        {
+            builder.UseContext(options => options.UseSqlite(sqlite.ConnectionString));
+        }
+    }
+}


### PR DESCRIPTION
* Fixing the configuration of the entity model for the Delivery Results in Entity Framework data layer
* Enhancing the query model of the Delivery Result repository to return the related entities
* New testing strategy for the Entity Framework data layer to support multiple storage systems (SQLite and MS SQL Server so far)